### PR TITLE
37 remove liberal use of systemout

### DIFF
--- a/src/main/java/ispd/gui/LoadConfigurationDialog.java
+++ b/src/main/java/ispd/gui/LoadConfigurationDialog.java
@@ -1351,10 +1351,7 @@ public class LoadConfigurationDialog extends JDialog {
         try {
             final var interpret = new TraceXML(this.jTextFieldCaminhoTrace.getText());
             try {//inicia a conversão do arquivo
-                final double t1 = System.currentTimeMillis();
                 interpret.convert();
-                final double t2 = System.currentTimeMillis();
-                System.out.println((t2 - t1) / 1000);
                 this.file            = new File(interpret.getSaida());
                 this.traceTaskNumber = interpret.getNum_Tasks();
                 this.traceType       = interpret.getTipo();

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -6,9 +6,7 @@ import javax.swing.*;
 
 public class Hardware {
 
-    public void showMessage (
-        final ProgressTracker janela
-    ) {
+    public static void showMessage (final ProgressTracker janela) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Hardware Failure selected.");
         janela.println("Hardware failure created.");

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -1,15 +1,13 @@
 package ispd.motor.faults;
 
 import ispd.gui.*;
-import ispd.motor.queues.*;
 import ispd.motor.simul.*;
 import javax.swing.*;
 
 public class Hardware {
 
     public void showMessage (
-        final ProgressTracker janela,
-        final CloudQueueNetwork gridQueueNetwork
+        final ProgressTracker janela
     ) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Hardware Failure selected.");

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -9,15 +9,6 @@ import javax.swing.*;
 
 public class Hardware {
 
-    private static void printNewQueueNetwork (
-        final List<VirtualMachine> vms,
-        final List<CloudMachine> machines
-    ) {
-        final int qn = machines.size() - 1;
-        for (int i = 0; i <= qn; i++) {
-        }
-    }
-
     private static void selectFaults (final ProgressTracker janela) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Hardware Failure selected.");
@@ -65,7 +56,5 @@ public class Hardware {
                           id,
                           CloudMachine.DESLIGADO
         );
-
-        printNewQueueNetwork(vms, machines);
     }
 }

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -7,7 +7,7 @@ import javax.swing.*;
 
 public class Hardware {
 
-    public void FIHardware1 (
+    public void showMessage (
         final ProgressTracker janela,
         final CloudQueueNetwork gridQueueNetwork
     ) {

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -6,10 +6,10 @@ import javax.swing.*;
 
 public class Hardware {
 
-    public static void showMessage (final ProgressTracker janela) {
+    public static void showMessage (final ProgressTracker progressTracker) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Hardware Failure selected.");
-        janela.println("Hardware failure created.");
-        janela.print(" -> ");
+        progressTracker.println("Hardware failure created.");
+        progressTracker.print(" -> ");
     }
 }

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -3,32 +3,17 @@ package ispd.motor.faults;
 import ispd.gui.*;
 import ispd.motor.queues.*;
 import ispd.motor.simul.*;
-import java.util.*;
 import javax.swing.*;
 
 public class Hardware {
-
-    private static void selectFaults (final ProgressTracker janela) {
-        new PickSimulationFaultsDialog();
-        JOptionPane.showMessageDialog(null, "Hardware Failure selected.");
-        janela.println("Hardware failure created.");
-        janela.print(" -> ");
-    }
 
     public void FIHardware1 (
         final ProgressTracker janela,
         final CloudQueueNetwork gridQueueNetwork
     ) {
-        selectFaults(janela);
-
-        final var vms = gridQueueNetwork.getVMs();
-
-
-        if (vms == null) {
-            return;
-        }
-
-        final var machines = gridQueueNetwork.getMaquinasCloud();
-        final int id       = new Random().nextInt(machines.size());
+        new PickSimulationFaultsDialog();
+        JOptionPane.showMessageDialog(null, "Hardware Failure selected.");
+        janela.println("Hardware failure created.");
+        janela.print(" -> ");
     }
 }

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -14,13 +14,7 @@ public class Hardware {
         final List<CloudMachine> machines
     ) {
         final int qn = machines.size() - 1;
-        System.out.printf("Novo redeDeFilas: %d\n", qn);
         for (int i = 0; i <= qn; i++) {
-            System.out.printf("""
-                              Novo Rede de Filas: %d
-                              Novo Rede de Filas Cloud get VMs: %s
-                              Novo Rede de Filas Cloud: getMaquinasCloud: %s
-                              """, qn, vms, machines);
         }
     }
 

--- a/src/main/java/ispd/motor/faults/Hardware.java
+++ b/src/main/java/ispd/motor/faults/Hardware.java
@@ -2,7 +2,6 @@ package ispd.motor.faults;
 
 import ispd.gui.*;
 import ispd.motor.queues.*;
-import ispd.motor.queues.centers.impl.*;
 import ispd.motor.simul.*;
 import java.util.*;
 import javax.swing.*;
@@ -24,37 +23,12 @@ public class Hardware {
 
         final var vms = gridQueueNetwork.getVMs();
 
-        System.out.println("---------------------------------------");
 
         if (vms == null) {
-            System.out.println("Rede de filas é nula na classe " + "CloudSequential.java");
             return;
         }
 
         final var machines = gridQueueNetwork.getMaquinasCloud();
         final int id       = new Random().nextInt(machines.size());
-
-        System.out.printf("""
-                          Rede de filas das VMs não é nula na classe CloudSequential.java
-                          Listagem da rede de filas:
-                          Rede de Filas: %s
-                          Rede de Filas get VMs: %s
-                          Há máquinas alocadas no redeDeFilas
-                          Rede de Filas Cloud get PMs: %s
-                          Rede de Filas Cloud: getMaquinasCloud: %s
-                          Quantidade de Máquinas alocadas ao mestre: %d
-                          Número da posição da maquina sorteada: %d
-                          Máquina sorteada desligada: %d
-                          Máquina que o status é igual a 2: %d
-                          """,
-                          gridQueueNetwork,
-                          vms,
-                          vms,
-                          machines,
-                          machines.size(),
-                          id,
-                          id,
-                          CloudMachine.DESLIGADO
-        );
     }
 }

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -2,9 +2,7 @@ package ispd.motor.faults;
 
 import ispd.gui.*;
 import ispd.motor.queues.*;
-import ispd.motor.queues.centers.impl.*;
 import ispd.motor.simul.*;
-import java.util.*;
 import javax.swing.*;
 
 public class Software {
@@ -19,18 +17,9 @@ public class Software {
             return;
         }
 
-        //sorteio de máquina alocada ao mestre  Falha de omissão de hardware:
-        final Random random = new Random();
-        int          draw   = random.nextInt(redeDeFilas.getMaquinasCloud().size());
-        //tornar a posição sorteada ==Desligada
-        draw = CloudMachine.DESLIGADO;
-
         final int NovoRedeDeFilas = redeDeFilas.getMaquinasCloud().size() - 1;
 
-        //escreva o vetor redeDeFilas com a posição [draw} com status == DESLIGADO
         for (int i = 0; i <= NovoRedeDeFilas; i++) {
         }
-        //Refazer o escalonamento: Técnica: Regate do Workflow??? ou Redistribuição das tarefas??
-
     }
 }

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -1,13 +1,12 @@
 package ispd.motor.faults;
 
 import ispd.gui.*;
-import ispd.motor.queues.*;
 import ispd.motor.simul.*;
 import javax.swing.*;
 
 public class Software {
 
-    public void FISfotware1 (final ProgressTracker janela, final CloudQueueNetwork redeDeFilas) {
+    public void FISfotware1 (final ProgressTracker janela) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Falha de Omissão de software selecionada.");
         janela.println("Software failure created.");

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -6,7 +6,7 @@ import javax.swing.*;
 
 public class Software {
 
-    public void FISfotware1 (final ProgressTracker janela) {
+    public void showMessage (final ProgressTracker janela) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Falha de Omissão de software selecionada.");
         janela.println("Software failure created.");

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -15,7 +15,7 @@ public class Software {
 
         janela.println("Software failure created.");
 
-        if (redeDeFilas.getVMs() != null && (redeDeFilas.getVMs() != null)) {
+        if (redeDeFilas.getVMs() != null) {
             System.out.println("---------------------------------------");
             System.out.println("Rede de filas das VMs não é nula na classe CloudSequential.java");
             System.out.println("Listagem da rede de filas: ");

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -19,37 +19,16 @@ public class Software {
             return;
         }
 
-        System.out.println("---------------------------------------");
-        System.out.println("Rede de filas das VMs não é nula na classe CloudSequential.java");
-        System.out.println("Listagem da rede de filas: ");
-        System.out.println("Rede de Filas: " + redeDeFilas);
-        System.out.println("Rede de Filas get VMs: " + redeDeFilas.getVMs());
-        System.out.println("Há máquinas alocadas no redeDeFilas");
-        System.out.println("Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
-        System.out.println("Rede de Filas Cloud: getMaquinasCloud: "
-                           + redeDeFilas.getMaquinasCloud());
-        System.out.println("Quantidade de Máquinas alocadas ao mestre: " + redeDeFilas
-            .getMaquinasCloud()
-            .size());
         //sorteio de máquina alocada ao mestre  Falha de omissão de hardware:
         final Random random = new Random();
         int          draw   = random.nextInt(redeDeFilas.getMaquinasCloud().size());
-        System.out.println("Número da posição da maquina sorteada: " + draw); //Exemplo: [27]
-        System.out.println("Máquina sorteada desligada: " + draw);
         //tornar a posição sorteada ==Desligada
         draw = CloudMachine.DESLIGADO;
-        System.out.println(
-            "Status da máquina desligada => public static final int DESLIGADO = 2: " + draw);
 
         final int NovoRedeDeFilas = redeDeFilas.getMaquinasCloud().size() - 1;
-        System.out.println("Novo redeDeFilas: " + NovoRedeDeFilas);
 
         //escreva o vetor redeDeFilas com a posição [draw} com status == DESLIGADO
         for (int i = 0; i <= NovoRedeDeFilas; i++) {
-            System.out.println("Novo Rede de Filas: " + NovoRedeDeFilas);
-            System.out.println("Novo Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
-            System.out.println("Novo Rede de Filas Cloud: getMaquinasCloud: "
-                               + redeDeFilas.getMaquinasCloud());
         }
         //Refazer o escalonamento: Técnica: Regate do Workflow??? ou Redistribuição das tarefas??
 

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -10,11 +10,7 @@ import javax.swing.*;
 public class Software {
 
     public void FISfotware1 (final ProgressTracker janela, final CloudQueueNetwork redeDeFilas) {
-        System.out.println("Estou em public FISoftware!! XD ");
-        //declaração das variáveis locais
-        //Criação de um instância para a classe JSelecionarFalhas
         new PickSimulationFaultsDialog();
-        //Confirmação do tipo de falha selecionada: Falha por omissão de hardware
         JOptionPane.showMessageDialog(null, "Falha de Omissão de software selecionada.");
 
         janela.println("Software failure created.");

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -15,12 +15,7 @@ public class Software {
 
         janela.println("Software failure created.");
 
-        if (redeDeFilas.getVMs() == null) {
-            System.out.println("---------------------------------------");
-            System.out.println("Rede de filas é nula na classe CloudSequential.java");
-        }
-        //Se a redeDeFilas for diferente de nulo, então
-        else if (redeDeFilas.getVMs() != null) {
+        if (redeDeFilas.getVMs() != null && (redeDeFilas.getVMs() != null)) {
             System.out.println("---------------------------------------");
             System.out.println("Rede de filas das VMs não é nula na classe CloudSequential.java");
             System.out.println("Listagem da rede de filas: ");
@@ -28,8 +23,11 @@ public class Software {
             System.out.println("Rede de Filas get VMs: " + redeDeFilas.getVMs());
             System.out.println("Há máquinas alocadas no redeDeFilas");
             System.out.println("Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
-            System.out.println("Rede de Filas Cloud: getMaquinasCloud: " + redeDeFilas.getMaquinasCloud());
-            System.out.println("Quantidade de Máquinas alocadas ao mestre: " + redeDeFilas.getMaquinasCloud().size());
+            System.out.println("Rede de Filas Cloud: getMaquinasCloud: "
+                               + redeDeFilas.getMaquinasCloud());
+            System.out.println("Quantidade de Máquinas alocadas ao mestre: " + redeDeFilas
+                .getMaquinasCloud()
+                .size());
             //sorteio de máquina alocada ao mestre  Falha de omissão de hardware:
             final Random random = new Random();
             int          draw   = random.nextInt(redeDeFilas.getMaquinasCloud().size());
@@ -37,7 +35,8 @@ public class Software {
             System.out.println("Máquina sorteada desligada: " + draw);
             //tornar a posição sorteada ==Desligada
             draw = CloudMachine.DESLIGADO;
-            System.out.println("Status da máquina desligada => public static final int DESLIGADO = 2: " + draw);
+            System.out.println(
+                "Status da máquina desligada => public static final int DESLIGADO = 2: " + draw);
 
             final int NovoRedeDeFilas = redeDeFilas.getMaquinasCloud().size() - 1;
             System.out.println("Novo redeDeFilas: " + NovoRedeDeFilas);
@@ -46,9 +45,11 @@ public class Software {
             for (int i = 0; i <= NovoRedeDeFilas; i++) {
                 System.out.println("Novo Rede de Filas: " + NovoRedeDeFilas);
                 System.out.println("Novo Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
-                System.out.println("Novo Rede de Filas Cloud: getMaquinasCloud: " + redeDeFilas.getMaquinasCloud());
+                System.out.println("Novo Rede de Filas Cloud: getMaquinasCloud: "
+                                   + redeDeFilas.getMaquinasCloud());
             }
             //Refazer o escalonamento: Técnica: Regate do Workflow??? ou Redistribuição das tarefas??
+
         }
     }
 }

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -10,16 +10,6 @@ public class Software {
     public void FISfotware1 (final ProgressTracker janela, final CloudQueueNetwork redeDeFilas) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Falha de Omissão de software selecionada.");
-
         janela.println("Software failure created.");
-
-        if (redeDeFilas.getVMs() == null) {
-            return;
-        }
-
-        final int NovoRedeDeFilas = redeDeFilas.getMaquinasCloud().size() - 1;
-
-        for (int i = 0; i <= NovoRedeDeFilas; i++) {
-        }
     }
 }

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -4,9 +4,10 @@ import ispd.gui.*;
 import ispd.motor.simul.*;
 import javax.swing.*;
 
-public class Software {
+public enum Software {
+    ;
 
-    public void showMessage (final ProgressTracker janela) {
+    public static void showMessage (final ProgressTracker janela) {
         new PickSimulationFaultsDialog();
         JOptionPane.showMessageDialog(null, "Falha de Omissão de software selecionada.");
         janela.println("Software failure created.");

--- a/src/main/java/ispd/motor/faults/Software.java
+++ b/src/main/java/ispd/motor/faults/Software.java
@@ -15,41 +15,43 @@ public class Software {
 
         janela.println("Software failure created.");
 
-        if (redeDeFilas.getVMs() != null) {
-            System.out.println("---------------------------------------");
-            System.out.println("Rede de filas das VMs não é nula na classe CloudSequential.java");
-            System.out.println("Listagem da rede de filas: ");
-            System.out.println("Rede de Filas: " + redeDeFilas);
-            System.out.println("Rede de Filas get VMs: " + redeDeFilas.getVMs());
-            System.out.println("Há máquinas alocadas no redeDeFilas");
-            System.out.println("Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
-            System.out.println("Rede de Filas Cloud: getMaquinasCloud: "
-                               + redeDeFilas.getMaquinasCloud());
-            System.out.println("Quantidade de Máquinas alocadas ao mestre: " + redeDeFilas
-                .getMaquinasCloud()
-                .size());
-            //sorteio de máquina alocada ao mestre  Falha de omissão de hardware:
-            final Random random = new Random();
-            int          draw   = random.nextInt(redeDeFilas.getMaquinasCloud().size());
-            System.out.println("Número da posição da maquina sorteada: " + draw); //Exemplo: [27]
-            System.out.println("Máquina sorteada desligada: " + draw);
-            //tornar a posição sorteada ==Desligada
-            draw = CloudMachine.DESLIGADO;
-            System.out.println(
-                "Status da máquina desligada => public static final int DESLIGADO = 2: " + draw);
-
-            final int NovoRedeDeFilas = redeDeFilas.getMaquinasCloud().size() - 1;
-            System.out.println("Novo redeDeFilas: " + NovoRedeDeFilas);
-
-            //escreva o vetor redeDeFilas com a posição [draw} com status == DESLIGADO
-            for (int i = 0; i <= NovoRedeDeFilas; i++) {
-                System.out.println("Novo Rede de Filas: " + NovoRedeDeFilas);
-                System.out.println("Novo Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
-                System.out.println("Novo Rede de Filas Cloud: getMaquinasCloud: "
-                                   + redeDeFilas.getMaquinasCloud());
-            }
-            //Refazer o escalonamento: Técnica: Regate do Workflow??? ou Redistribuição das tarefas??
-
+        if (redeDeFilas.getVMs() == null) {
+            return;
         }
+
+        System.out.println("---------------------------------------");
+        System.out.println("Rede de filas das VMs não é nula na classe CloudSequential.java");
+        System.out.println("Listagem da rede de filas: ");
+        System.out.println("Rede de Filas: " + redeDeFilas);
+        System.out.println("Rede de Filas get VMs: " + redeDeFilas.getVMs());
+        System.out.println("Há máquinas alocadas no redeDeFilas");
+        System.out.println("Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
+        System.out.println("Rede de Filas Cloud: getMaquinasCloud: "
+                           + redeDeFilas.getMaquinasCloud());
+        System.out.println("Quantidade de Máquinas alocadas ao mestre: " + redeDeFilas
+            .getMaquinasCloud()
+            .size());
+        //sorteio de máquina alocada ao mestre  Falha de omissão de hardware:
+        final Random random = new Random();
+        int          draw   = random.nextInt(redeDeFilas.getMaquinasCloud().size());
+        System.out.println("Número da posição da maquina sorteada: " + draw); //Exemplo: [27]
+        System.out.println("Máquina sorteada desligada: " + draw);
+        //tornar a posição sorteada ==Desligada
+        draw = CloudMachine.DESLIGADO;
+        System.out.println(
+            "Status da máquina desligada => public static final int DESLIGADO = 2: " + draw);
+
+        final int NovoRedeDeFilas = redeDeFilas.getMaquinasCloud().size() - 1;
+        System.out.println("Novo redeDeFilas: " + NovoRedeDeFilas);
+
+        //escreva o vetor redeDeFilas com a posição [draw} com status == DESLIGADO
+        for (int i = 0; i <= NovoRedeDeFilas; i++) {
+            System.out.println("Novo Rede de Filas: " + NovoRedeDeFilas);
+            System.out.println("Novo Rede de Filas Cloud get VMs: " + redeDeFilas.getVMs());
+            System.out.println("Novo Rede de Filas Cloud: getMaquinasCloud: "
+                               + redeDeFilas.getMaquinasCloud());
+        }
+        //Refazer o escalonamento: Técnica: Regate do Workflow??? ou Redistribuição das tarefas??
+
     }
 }

--- a/src/main/java/ispd/motor/faults/State.java
+++ b/src/main/java/ispd/motor/faults/State.java
@@ -7,29 +7,8 @@ import javax.swing.*;
 public class State {
 
     public void FIState1 (final ProgressTracker janela, final CloudQueueNetwork redeDeFilas) {
-        // Mensagens com a inserção de falha
         JOptionPane.showMessageDialog(null, "State transmission failure detected.");
         janela.println("State transmission fault created.");
         janela.println("->");
-
-        // Criação de filas vazias para armazenamento das máquinas antes da falha
-
-        // Processo de falha e tratamento
-        if (redeDeFilas.getVMs() == null) {
-        } else if (redeDeFilas.getVMs() != null) {
-            // Criação de números aleatórios para impedir o estado de transmissão
-            //Máquinas da nuvem
-
-            // Máquina desligada para impedir que a transmissão seja feita
-
-            // Nova máquina para ser replicada
-
-            // Número de VMs na simulação
-            final double machineNumber = redeDeFilas.getMaquinasCloud().size();
-
-            // Método de recuperação - Replicação
-            for (int i = 0; i < machineNumber; i++) {
-            }
-        }
     }
 }

--- a/src/main/java/ispd/motor/faults/State.java
+++ b/src/main/java/ispd/motor/faults/State.java
@@ -3,9 +3,10 @@ package ispd.motor.faults;
 import ispd.motor.simul.*;
 import javax.swing.*;
 
-public class State {
+public enum State {
+    ;
 
-    public void FIState1 (final ProgressTracker progressTracker) {
+    public static void showMessage (final ProgressTracker progressTracker) {
         JOptionPane.showMessageDialog(null, "State transmission failure detected.");
         progressTracker.println("State transmission fault created.");
         progressTracker.println("->");

--- a/src/main/java/ispd/motor/faults/State.java
+++ b/src/main/java/ispd/motor/faults/State.java
@@ -1,14 +1,13 @@
 package ispd.motor.faults;
 
-import ispd.motor.queues.*;
 import ispd.motor.simul.*;
 import javax.swing.*;
 
 public class State {
 
-    public void FIState1 (final ProgressTracker janela, final CloudQueueNetwork redeDeFilas) {
+    public void FIState1 (final ProgressTracker progressTracker) {
         JOptionPane.showMessageDialog(null, "State transmission failure detected.");
-        janela.println("State transmission fault created.");
-        janela.println("->");
+        progressTracker.println("State transmission fault created.");
+        progressTracker.println("->");
     }
 }

--- a/src/main/java/ispd/motor/faults/State.java
+++ b/src/main/java/ispd/motor/faults/State.java
@@ -1,9 +1,7 @@
 package ispd.motor.faults;
 
 import ispd.motor.queues.*;
-import ispd.motor.queues.centers.impl.*;
 import ispd.motor.simul.*;
-import java.util.*;
 import javax.swing.*;
 
 public class State {
@@ -20,26 +18,17 @@ public class State {
         if (redeDeFilas.getVMs() == null) {
         } else if (redeDeFilas.getVMs() != null) {
             // Criação de números aleatórios para impedir o estado de transmissão
-            final Random cloudMachines = new Random(); //Máquinas da nuvem
-            double       machineDown   = cloudMachines.nextInt(redeDeFilas.getMaquinasCloud().size());
+            //Máquinas da nuvem
 
             // Máquina desligada para impedir que a transmissão seja feita
-            machineDown = CloudMachine.DESLIGADO;
 
             // Nova máquina para ser replicada
-            double newMachine = machineDown;
 
             // Número de VMs na simulação
             final double machineNumber = redeDeFilas.getMaquinasCloud().size();
 
             // Método de recuperação - Replicação
             for (int i = 0; i < machineNumber; i++) {
-                if (machineDown == 2) {
-                    machineDown = newMachine;
-                    newMachine = CloudMachine.DESLIGADO;
-                } else {
-                    janela.println("Nenhuma máquina com falha encontrada!");
-                }
             }
         }
     }

--- a/src/main/java/ispd/motor/faults/State.java
+++ b/src/main/java/ispd/motor/faults/State.java
@@ -18,8 +18,6 @@ public class State {
 
         // Processo de falha e tratamento
         if (redeDeFilas.getVMs() == null) {
-            System.out.println("---------------------------------------");
-            System.out.println("Rede de filas é nula.");
         } else if (redeDeFilas.getVMs() != null) {
             // Criação de números aleatórios para impedir o estado de transmissão
             final Random cloudMachines = new Random(); //Máquinas da nuvem

--- a/src/main/java/ispd/motor/faults/Value.java
+++ b/src/main/java/ispd/motor/faults/Value.java
@@ -22,9 +22,7 @@ public class Value {
         //Criação de filas vazias para armazenamento das máquinas antes da falha
 
         //Processo de falha e tratamento
-        if (redeDeFilas.getVMs() == null) {
-
-        } else if (redeDeFilas.getVMs() != null) {
+        if ((redeDeFilas.getVMs() != null) && (redeDeFilas.getVMs() != null)) {
             //Variáveis para recuperação
             final double OciosidadeComputacaoOri  = global.getOciosidadeComputacao();
             final double OciosidadeComunicacaoOri = global.getOciosidadeComunicacao();
@@ -34,7 +32,8 @@ public class Value {
             //Criação de números aleatórios para alterações das respostas para usuários
             final Random cloudMachines = new Random(); //Máquinas da nuvem
 
-            final double metricsCloud = cloudMachines.nextInt(redeDeFilas.getMaquinasCloud().size());
+            final double metricsCloud =
+                cloudMachines.nextInt(redeDeFilas.getMaquinasCloud().size());
 
             global.setOciosidadeComputacao(metricsCloud / 100);
             global.setOciosidadeComunicacao(metricsCloud);
@@ -52,6 +51,7 @@ public class Value {
                 global.setSatisfacaoMedia(SatisfacaoMediaOri);
                 global.setEficiencia(EficienciaOri);
             }
+
         }
     }
 }

--- a/src/main/java/ispd/motor/faults/Value.java
+++ b/src/main/java/ispd/motor/faults/Value.java
@@ -9,7 +9,7 @@ import javax.swing.*;
 public class Value {
 
     //Método para inserção de falha de resposta
-    public void FIValue1 (
+    public void setFaults (
         final ProgressTracker janela,
         final CloudQueueNetwork redeDeFilas,
         final Global global

--- a/src/main/java/ispd/motor/faults/Value.java
+++ b/src/main/java/ispd/motor/faults/Value.java
@@ -23,8 +23,6 @@ public class Value {
 
         //Processo de falha e tratamento
         if (redeDeFilas.getVMs() == null) {
-            System.out.println("---------------------------------------");
-            System.out.println("Rede de filas é nula.");
 
         } else if (redeDeFilas.getVMs() != null) {
             //Variáveis para recuperação

--- a/src/main/java/ispd/motor/faults/Value.java
+++ b/src/main/java/ispd/motor/faults/Value.java
@@ -22,7 +22,7 @@ public class Value {
         //Criação de filas vazias para armazenamento das máquinas antes da falha
 
         //Processo de falha e tratamento
-        if ((redeDeFilas.getVMs() != null) && (redeDeFilas.getVMs() != null)) {
+        if (redeDeFilas.getVMs() != null) {
             //Variáveis para recuperação
             final double OciosidadeComputacaoOri  = global.getOciosidadeComputacao();
             final double OciosidadeComunicacaoOri = global.getOciosidadeComunicacao();

--- a/src/main/java/ispd/motor/faults/Value.java
+++ b/src/main/java/ispd/motor/faults/Value.java
@@ -6,10 +6,11 @@ import ispd.motor.simul.*;
 import java.util.*;
 import javax.swing.*;
 
-public class Value {
+public enum Value {
+    ;
 
     //Método para inserção de falha de resposta
-    public void setFaults (
+    public static void setFaults (
         final ProgressTracker janela,
         final CloudQueueNetwork redeDeFilas,
         final Global global

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -96,7 +96,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
         if (cliente instanceof final CloudTask trf) {
             final var vm = trf.getVM_enviada();
-            if (this.hosts(vm)) {
+            if (this.isHosting(vm)) {
                 if (this.VMs.contains(vm)) {
                 } else {
                     final var evtFut = new Event(
@@ -117,7 +117,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             //procedimento caso cliente seja uma tarefa!
             final var vm = (VirtualMachine) cliente.getLocalProcessamento();
             final Event evtFut;
-            if (this.hosts(vm)) {
+            if (this.isHosting(vm)) {
                 //se a tarefa é endereçada pra uma VM qu está alocada nessa máquina
                 evtFut = new Event(
                     simulacao.getTime(this), EventType.ARRIVAL, vm, cliente
@@ -131,7 +131,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         }
     }
 
-    private boolean hosts (final VirtualMachine vm) {
+    private boolean isHosting (final VirtualMachine vm) {
         return vm.getMaquinaHospedeira().equals(this);
     }
 

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -188,9 +188,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
     @Override
     public void clientExit (final Simulation simulacao, final GridTask cliente) {
-        System.out.println("--------------------------------------");
-        System.out.println(this.id() + ": Saída de cliente");
-        System.out.println("--------------------------------------");
     }
 
     @Override

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -342,8 +342,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     public void handleAllocationAck (final Simulation simulacao, final Request request) {
         //quem deve resolver esse método é o VMM de origem
         //portanto as maquinas só encaminham pro próximo centro de serviço.
-        System.out.println("--------------------------------------");
-        System.out.println("Encaminhando ACK de alocação para " + request.getOrigem().id());
         final var evt = new Event(
             simulacao.getTime(this), EventType.MESSAGE, request.getCaminho().remove(0), request
         );

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -94,26 +94,17 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
     @Override
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
-        System.out.println("----------------------------------------------");
-        System.out.println("Chegada de evento na  máquina " + this.id());
         if (cliente instanceof final CloudTask trf) {
             final VirtualMachine vm = trf.getVM_enviada();
             if (vm.getMaquinaHospedeira().equals(this)) {
                 if (this.VMs.contains(vm)) {
-                    System.out.println("Cliente duplicado!");
                 } else {
-                    System.out.println(vm.id()
-                                       + " enviada para evento de atendimento nesta máquina");
-                    System.out.println("----------------------------------------------");
                     final Event evtFut = new Event(
                         simulacao.getTime(this), EventType.SERVICE, this, cliente
                     );
                     simulacao.addFutureEvent(evtFut);
                 }
             } else {
-                System.out.println(vm.id()
-                                   + " encaminhada para seu destino, esta máquina é intermediária");
-                System.out.println("----------------------------------------------");
                 final Event evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.ARRIVAL,
@@ -127,20 +118,11 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             final VirtualMachine vm = (VirtualMachine) cliente.getLocalProcessamento();
             if (vm.getMaquinaHospedeira().equals(this)) {
                 //se a tarefa é endereçada pra uma VM qu está alocada nessa máquina
-                System.out.println(this.id() + ": Tarefa " + cliente.getIdentificador() +
-                                   " sendo enviada para execução na vm " + vm.id());
-                System.out.println("----------------------------------------------");
                 final Event evtFut = new Event(
                     simulacao.getTime(this), EventType.ARRIVAL, vm, cliente
                 );
                 simulacao.addFutureEvent(evtFut);
             } else {
-                System.out.println(
-                    this.id()
-                    + ": Tarefa "
-                    + cliente.getIdentificador()
-                    + " sendo encaminhada para próximo CS");
-                System.out.println("----------------------------------------------");
                 final Event evtFut = new Event(
                     simulacao.getTime(this), EventType.EXIT, this, cliente
                 );

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -95,17 +95,17 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     @Override
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
         if (cliente instanceof final CloudTask trf) {
-            final VirtualMachine vm = trf.getVM_enviada();
+            final var vm = trf.getVM_enviada();
             if (vm.getMaquinaHospedeira().equals(this)) {
                 if (this.VMs.contains(vm)) {
                 } else {
-                    final Event evtFut = new Event(
+                    final var evtFut = new Event(
                         simulacao.getTime(this), EventType.SERVICE, this, cliente
                     );
                     simulacao.addFutureEvent(evtFut);
                 }
             } else {
-                final Event evtFut = new Event(
+                final var evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.ARRIVAL,
                     cliente.getCaminho().remove(0),
@@ -115,15 +115,15 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             }
         } else {
             //procedimento caso cliente seja uma tarefa!
-            final VirtualMachine vm = (VirtualMachine) cliente.getLocalProcessamento();
+            final var vm = (VirtualMachine) cliente.getLocalProcessamento();
             if (vm.getMaquinaHospedeira().equals(this)) {
                 //se a tarefa é endereçada pra uma VM qu está alocada nessa máquina
-                final Event evtFut = new Event(
+                final var evtFut = new Event(
                     simulacao.getTime(this), EventType.ARRIVAL, vm, cliente
                 );
                 simulacao.addFutureEvent(evtFut);
             } else {
-                final Event evtFut = new Event(
+                final var evtFut = new Event(
                     simulacao.getTime(this), EventType.EXIT, this, cliente
                 );
                 simulacao.addFutureEvent(evtFut);
@@ -133,38 +133,38 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
     @Override
     public void clientProcessing (final Simulation simulacao, final GridTask cliente) {
-        final CloudTask trf = (CloudTask) cliente;
-        final VirtualMachine vm  = trf.getVM_enviada();
+        final var trf = (CloudTask) cliente;
+        final var vm  = trf.getVM_enviada();
         System.out.println("--------------------------------------------------");
         System.out.println("atendimento da vm:" + vm.id() + "na maquina:" + this.id());
         this.addVM(vm); //incluir a VM na lista de VMs
         this.metricaAloc.incVMsAlocadas();
         //Setar o caminho da vm para o VMM e o caminho do ACK da mensagem >>>
-        final CloudMaster vmm   = vm.getVmmResponsavel();
-        final int         index = this.mestres.indexOf(vmm);
-        final Request     msg   = new Request(this, RequestType.ALLOCATION_ACK, cliente);
+        final var vmm   = vm.getVmmResponsavel();
+        final var index = this.mestres.indexOf(vmm);
+        final var msg   = new Request(this, RequestType.ALLOCATION_ACK, cliente);
 
         if (index == -1) {
-            final ArrayList<Service> caminhoVMM =
-                new ArrayList<>(getMenorCaminhoIndiretoCloud(this, vmm));
-            final ArrayList<Service> caminhoMsg =
-                new ArrayList<>(getMenorCaminhoIndiretoCloud(this, vmm));
+            final var caminhoVMM =
+                new ArrayList<Service>(getMenorCaminhoIndiretoCloud(this, vmm));
+            final var caminhoMsg =
+                new ArrayList<Service>(getMenorCaminhoIndiretoCloud(this, vmm));
 
             System.out.println("Imprimindo caminho para o mestre:");
-            for (final Service cs : caminhoVMM) {
+            for (final var cs : caminhoVMM) {
                 System.out.println(cs.id());
             }
 
             vm.setCaminhoVMM(caminhoVMM);
             msg.setCaminho(caminhoMsg);
         } else {
-            final ArrayList<Service> caminhoVMM =
+            final var caminhoVMM =
                 new ArrayList<Service>(this.caminhoMestre.get(index));
-            final ArrayList<Service> caminhoMsg =
+            final var caminhoMsg =
                 new ArrayList<Service>(this.caminhoMestre.get(index));
 
             System.out.println("Imprimindo caminho para o mestre:");
-            for (final Service cs : caminhoVMM) {
+            for (final var cs : caminhoVMM) {
                 System.out.println(cs.id());
             }
             vm.setCaminhoVMM(caminhoVMM);
@@ -172,7 +172,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         }
 
         //enviar mensagem de ACK para o VMM
-        final Event NovoEvt =
+        final var NovoEvt =
             new Event(simulacao.getTime(this), EventType.MESSAGE, this, msg);
         simulacao.addFutureEvent(NovoEvt);
 
@@ -236,9 +236,9 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
     @Override
     public void handleReturn (final Simulation simulacao, final Request request) {
-        final boolean remover = this.filaTarefas.remove(request.getTarefa());
+        final var remover = this.filaTarefas.remove(request.getTarefa());
         if (remover) {
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
                 request.getTarefa().getOrigem(),
@@ -261,17 +261,17 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
                 this.processadoresDisponiveis++;
             } else {
                 //Gera evento para atender proximo cliente da lista
-                final GridTask proxCliente = this.filaTarefas.remove(0);
-                final Event evtFut = new Event(
+                final var proxCliente = this.filaTarefas.remove(0);
+                final var evtFut = new Event(
                     simulacao.getTime(this), EventType.SERVICE, this, proxCliente
                 );
                 //Event adicionado a lista de evntos futuros
                 simulacao.addFutureEvent(evtFut);
             }
         }
-        final double inicioAtendimento = request.getTarefa().cancelar(simulacao.getTime(this));
-        final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-        final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+        final var inicioAtendimento = request.getTarefa().cancelar(simulacao.getTime(this));
+        final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+        final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
         //Incrementa o número de Mflops processados por este recurso
         this.getMetrica().incMflopsProcessados(mflopsProcessados);
         //Incrementa o tempo de processamento
@@ -283,16 +283,16 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     @Override
     public void handleUpdate (final Simulation simulacao, final Request request) {
         //enviar resultados
-        final int index = this.mestres.indexOf(request.getOrigem());
+        final var index = this.mestres.indexOf(request.getOrigem());
         final List<Service> caminho =
             new ArrayList<>((List<Service>) this.caminhoMestre.get(index));
-        final Request novaRequest =
+        final var novaRequest =
             new Request(this, request.getTamComunicacao(), RequestType.UPDATE_RESULT);
         //Obtem informações dinâmicas
         novaRequest.setProcessadorEscravo(new ArrayList<>(this.tarefaEmExecucao));
         novaRequest.setFilaEscravo(new ArrayList<>(this.filaTarefas));
         novaRequest.setCaminho(caminho);
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             simulacao.getTime(this),
             EventType.MESSAGE,
             novaRequest.getCaminho().remove(0),
@@ -310,25 +310,25 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     @Override
     public void handleFailure (final Simulation simulacao, final Request request) {
         final double tempoRec = this.recuperacao.remove(0);
-        for (final GridTask tar : this.tarefaEmExecucao) {
+        for (final var tar : this.tarefaEmExecucao) {
             if (tar.getEstado() == TaskState.PROCESSING) {
-                final double inicioAtendimento = tar.parar(simulacao.getTime(this));
-                final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-                final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+                final var inicioAtendimento = tar.parar(simulacao.getTime(this));
+                final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+                final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
                 //Incrementa o número de Mflops processados por este recurso
                 this.getMetrica().incMflopsProcessados(mflopsProcessados);
                 //Incrementa o tempo de processamento
                 this.getMetrica().incSegundosDeProcessamento(tempoProc);
                 //Incrementa procentagem da tarefa processada
                 // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
-                final int numCP = (int) (mflopsProcessados / 0.0);
+                final var numCP = (int) (mflopsProcessados / 0.0);
                 // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
                 tar.setMflopsProcessado(numCP * 0.0);
                 if (false) {
                     //Reiniciar atendimento da tarefa
                     tar.iniciarEsperaProcessamento(simulacao.getTime(this));
                     //cria evento para iniciar o atendimento imediatamente
-                    final Event novoEvt = new Event(
+                    final var novoEvt = new Event(
                         simulacao.getTime(this) + tempoRec,
                         EventType.SERVICE, this, tar
                     );
@@ -349,7 +349,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         //portanto as maquinas só encaminham pro próximo centro de serviço.
         System.out.println("--------------------------------------");
         System.out.println("Encaminhando ACK de alocação para " + request.getOrigem().id());
-        final Event evt = new Event(
+        final var evt = new Event(
             simulacao.getTime(this), EventType.MESSAGE, request.getCaminho().remove(0), request
         );
         simulacao.addFutureEvent(evt);
@@ -366,8 +366,8 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
                 this.processadoresDisponiveis++;
             } else {
                 //Gera evento para atender proximo cliente da lista
-                final GridTask proxCliente = this.filaTarefas.remove(0);
-                final Event evtFut =
+                final var proxCliente = this.filaTarefas.remove(0);
+                final var evtFut =
                     new Event(
                         simulacao.getTime(this),
                         EventType.SERVICE,
@@ -377,9 +377,9 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
                 //Event adicionado a lista de evntos futuros
                 simulacao.addFutureEvent(evtFut);
             }
-            final double inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
-            final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-            final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+            final var inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
+            final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+            final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
             //Incrementa o número de Mflops processados por este recurso
             this.getMetrica().incMflopsProcessados(mflopsProcessados);
             //Incrementa o tempo de processamento
@@ -393,7 +393,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
     @Override
     public void handleCancel (final Simulation simulacao, final Request request) {
-        boolean remover = false;
+        var remover = false;
         if (request.getTarefa().getEstado() == TaskState.BLOCKED) {
             remover = this.filaTarefas.remove(request.getTarefa());
         } else if (request.getTarefa().getEstado() == TaskState.PROCESSING) {
@@ -404,8 +404,8 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
                 this.processadoresDisponiveis++;
             } else {
                 //Gera evento para atender proximo cliente da lista
-                final GridTask proxCliente = this.filaTarefas.remove(0);
-                final Event evtFut =
+                final var proxCliente = this.filaTarefas.remove(0);
+                final var evtFut =
                     new Event(
                         simulacao.getTime(this),
                         EventType.SERVICE,
@@ -415,22 +415,22 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
                 //Event adicionado a lista de evntos futuros
                 simulacao.addFutureEvent(evtFut);
             }
-            final double inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
-            final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-            final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+            final var inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
+            final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+            final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
             //Incrementa o número de Mflops processados por este recurso
             this.getMetrica().incMflopsProcessados(mflopsProcessados);
             //Incrementa o tempo de processamento
             this.getMetrica().incSegundosDeProcessamento(tempoProc);
             //Incrementa procentagem da tarefa processada
             // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
-            final int numCP = (int) (mflopsProcessados / 0.0);
+            final var numCP = (int) (mflopsProcessados / 0.0);
             // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
             request.getTarefa().setMflopsProcessado(numCP * 0.0);
             this.tarefaEmExecucao.remove(request.getTarefa());
         }
         if (remover) {
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
                 request.getTarefa().getOrigem(),
@@ -454,7 +454,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             + " mestres");
 
         //Busca pelos caminhos
-        for (int i = 0; i < this.mestres.size(); i++) {
+        for (var i = 0; i < this.mestres.size(); i++) {
             this.caminhoMestre.add(i, getMenorCaminhoCloud(
                 this,
                 this.mestres.get(i)
@@ -462,7 +462,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         }
 
         //verifica se todos os mestres são alcansaveis
-        for (int i = 0; i < this.mestres.size(); i++) {
+        for (var i = 0; i < this.mestres.size(); i++) {
             if (this.caminhoMestre.get(i).isEmpty()) {
                 throw new LinkageError();
             }
@@ -515,7 +515,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     }
 
     public void desligar (final Simulation simulacao) {
-        for (final VirtualMachine vm : this.VMs) {
+        for (final var vm : this.VMs) {
             vm.setStatus(VirtualMachineState.DESTROYED);
             vm.setTempoDeExec(simulacao.getTime(this));
             vm

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -147,10 +147,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             final var caminhoMsg =
                 new ArrayList<>(getMenorCaminhoIndiretoCloud(this, vmm));
 
-            for (final var cs : caminhoVMM) {
-                System.out.println(cs.id());
-            }
-
             vm.setCaminhoVMM(caminhoVMM);
             msg.setCaminho(caminhoMsg);
         } else {
@@ -159,9 +155,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             final var caminhoMsg =
                 new ArrayList<Service>(this.caminhoMestre.get(index));
 
-            for (final var cs : caminhoVMM) {
-                System.out.println(cs.id());
-            }
             vm.setCaminhoVMM(caminhoVMM);
             msg.setCaminho(caminhoMsg);
         }

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -24,6 +24,12 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
     private final List<Processing> mestres = new ArrayList<>();
 
+    private final double custoProc;
+
+    private final double custoMemoria;
+
+    private final double custoDisco;
+
     private List<List> caminhoMestre = null;
 
     private int processadoresDisponiveis;
@@ -31,12 +37,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     private double memoriaDisponivel;
 
     private double discoDisponivel;
-
-    private final double custoProc;
-
-    private final double custoMemoria;
-
-    private final double custoDisco;
 
     private double custoTotalDisco = 0.0;
 
@@ -128,10 +128,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             }
             simulacao.addFutureEvent(evtFut);
         }
-    }
-
-    private boolean isHosting (final VirtualMachine vm) {
-        return vm.getMaquinaHospedeira().equals(this);
     }
 
     @Override
@@ -435,16 +431,9 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     }
 
     @Override
-    public void determinarCaminhos ()
-        throws LinkageError {
+    public void determinarCaminhos () throws LinkageError {
         //Instancia objetos
         this.caminhoMestre = new ArrayList<>(this.mestres.size());
-        System.out.println(
-            "maquina "
-            + this.id()
-            + " determinando caminhos para "
-            + this.mestres.size()
-            + " mestres");
 
         //Busca pelos caminhos
         for (var i = 0; i < this.mestres.size(); i++) {
@@ -465,6 +454,10 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     @Override
     public void addConexoesSaida (final Link conexao) {
         this.conexoesSaida.add(conexao);
+    }
+
+    private boolean isHosting (final VirtualMachine vm) {
+        return vm.getMaquinaHospedeira().equals(this);
     }
 
     private void addVM (final VirtualMachine vm) {

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -97,8 +97,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         if (cliente instanceof final CloudTask trf) {
             final var vm = trf.getVM_enviada();
             if (this.isHosting(vm)) {
-                if (this.VMs.contains(vm)) {
-                } else {
+                if (!this.VMs.contains(vm)) {
                     final var evtFut = new Event(
                         simulacao.getTime(this), EventType.SERVICE, this, cliente
                     );

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -116,18 +116,18 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         } else {
             //procedimento caso cliente seja uma tarefa!
             final var vm = (VirtualMachine) cliente.getLocalProcessamento();
+            final Event evtFut;
             if (vm.getMaquinaHospedeira().equals(this)) {
                 //se a tarefa é endereçada pra uma VM qu está alocada nessa máquina
-                final var evtFut = new Event(
+                evtFut = new Event(
                     simulacao.getTime(this), EventType.ARRIVAL, vm, cliente
                 );
-                simulacao.addFutureEvent(evtFut);
             } else {
-                final var evtFut = new Event(
+                evtFut = new Event(
                     simulacao.getTime(this), EventType.EXIT, this, cliente
                 );
-                simulacao.addFutureEvent(evtFut);
             }
+            simulacao.addFutureEvent(evtFut);
         }
     }
 

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -139,8 +139,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     public void clientProcessing (final Simulation simulacao, final GridTask cliente) {
         final var trf = (CloudTask) cliente;
         final var vm  = trf.getVM_enviada();
-        System.out.println("--------------------------------------------------");
-        System.out.println("atendimento da vm:" + vm.id() + "na maquina:" + this.id());
         this.addVM(vm); //incluir a VM na lista de VMs
         this.metricaAloc.incVMsAlocadas();
         //Setar o caminho da vm para o VMM e o caminho do ACK da mensagem >>>
@@ -154,7 +152,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             final var caminhoMsg =
                 new ArrayList<Service>(getMenorCaminhoIndiretoCloud(this, vmm));
 
-            System.out.println("Imprimindo caminho para o mestre:");
             for (final var cs : caminhoVMM) {
                 System.out.println(cs.id());
             }
@@ -167,7 +164,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             final var caminhoMsg =
                 new ArrayList<Service>(this.caminhoMestre.get(index));
 
-            System.out.println("Imprimindo caminho para o mestre:");
             for (final var cs : caminhoVMM) {
                 System.out.println(cs.id());
             }
@@ -188,7 +184,6 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         this.custoTotalDisco   = this.custoTotalDisco + (vm.getDiscoDisponivel() * this.custoDisco);
         //setar o poder de processamento da VM.
         vm.setPoderProcessamentoPorNucleo(this.getPoderComputacional());
-        System.out.println("----------------------------------------------------");
     }
 
     @Override

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -148,9 +148,9 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
 
         if (index == -1) {
             final var caminhoVMM =
-                new ArrayList<Service>(getMenorCaminhoIndiretoCloud(this, vmm));
+                new ArrayList<>(getMenorCaminhoIndiretoCloud(this, vmm));
             final var caminhoMsg =
-                new ArrayList<Service>(getMenorCaminhoIndiretoCloud(this, vmm));
+                new ArrayList<>(getMenorCaminhoIndiretoCloud(this, vmm));
 
             for (final var cs : caminhoVMM) {
                 System.out.println(cs.id());

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -96,7 +96,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
         if (cliente instanceof final CloudTask trf) {
             final var vm = trf.getVM_enviada();
-            if (vm.getMaquinaHospedeira().equals(this)) {
+            if (this.hostsVm(vm)) {
                 if (this.VMs.contains(vm)) {
                 } else {
                     final var evtFut = new Event(
@@ -117,7 +117,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             //procedimento caso cliente seja uma tarefa!
             final var vm = (VirtualMachine) cliente.getLocalProcessamento();
             final Event evtFut;
-            if (vm.getMaquinaHospedeira().equals(this)) {
+            if (this.hostsVm(vm)) {
                 //se a tarefa é endereçada pra uma VM qu está alocada nessa máquina
                 evtFut = new Event(
                     simulacao.getTime(this), EventType.ARRIVAL, vm, cliente
@@ -129,6 +129,10 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             }
             simulacao.addFutureEvent(evtFut);
         }
+    }
+
+    private boolean hostsVm (final VirtualMachine vm) {
+        return vm.getMaquinaHospedeira().equals(this);
     }
 
     @Override

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMachine.java
@@ -96,7 +96,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
         if (cliente instanceof final CloudTask trf) {
             final var vm = trf.getVM_enviada();
-            if (this.hostsVm(vm)) {
+            if (this.hosts(vm)) {
                 if (this.VMs.contains(vm)) {
                 } else {
                     final var evtFut = new Event(
@@ -117,7 +117,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
             //procedimento caso cliente seja uma tarefa!
             final var vm = (VirtualMachine) cliente.getLocalProcessamento();
             final Event evtFut;
-            if (this.hostsVm(vm)) {
+            if (this.hosts(vm)) {
                 //se a tarefa é endereçada pra uma VM qu está alocada nessa máquina
                 evtFut = new Event(
                     simulacao.getTime(this), EventType.ARRIVAL, vm, cliente
@@ -131,7 +131,7 @@ public class CloudMachine extends Processing implements RequestHandler, Vertex {
         }
     }
 
-    private boolean hostsVm (final VirtualMachine vm) {
+    private boolean hosts (final VirtualMachine vm) {
         return vm.getMaquinaHospedeira().equals(this);
     }
 

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -279,14 +279,10 @@ public class CloudMaster extends Processing implements VmMaster,
     @Override
     public void handleAllocationAck (final Simulation simulacao, final Request request) {
         // se este VMM for o de origem ele deve atender senão deve encaminhar a request para frente
-        System.out.println("--------------------------------------");
         final var trf    = (CloudTask) request.getTarefa();
         final var auxVM  = trf.getVM_enviada();
         final var auxMaq = auxVM.getMaquinaHospedeira();
-        System.out.println("Atendendo ACK de alocação da vm "
-                           + auxVM.id()
-                           + " na máquina "
-                           + auxMaq.id());
+
         if (auxVM.getVmmResponsavel().equals(this)) {
             // se o VMM responsável da VM for este.. tratar o ack
             // primeiro encontrar o caminho pra máquina onde a vm está alocada
@@ -301,12 +297,8 @@ public class CloudMaster extends Processing implements VmMaster,
             } else {
                 caminho = new ArrayList<Service>(this.caminhoEscravo.get(index));
             }
-            System.out.println(this.id()
-                               + ": Caminho encontrado para a vm"
-                               + " com tamanho: "
-                               + caminho.size());
+
             this.determinarCaminhoVM(auxVM, caminho);
-            System.out.println(auxVM.id() + " Alocada");
             auxVM.setStatus(VirtualMachineState.ALLOCATED);
             auxVM.setInstanteAloc(simulacao.getTime(this));
             if (!this.vmsAlocadas) {
@@ -316,11 +308,7 @@ public class CloudMaster extends Processing implements VmMaster,
         } else {
             // passar adiante, encontrando antes o caminho intermediário para poder escalonar tarefas desse VMM tbm
             //  para a vm hierarquica
-            System.out.println(
-                this.id()
-                + ": VMM intermediário, definindo"
-                + " caminho intermediário para "
-                + auxVM.id());
+
             if (this.escalonador.getEscravos().contains(auxVM)) {
                 final var index =
                     this.alocadorVM.getEscravos().indexOf(auxMaq);
@@ -332,9 +320,7 @@ public class CloudMaster extends Processing implements VmMaster,
                 } else {
                     caminho = new ArrayList<Service>(this.caminhoEscravo.get(index));
                 }
-                System.out.println("Caminho encontrado para a vm com tamanho:"
-                                   + " "
-                                   + caminho.size());
+
                 this.determinarCaminhoVM(auxVM, caminho);
             }
             final var evt = new Event(

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -63,8 +63,7 @@ public class CloudMaster extends Processing implements VmMaster,
             final VirtualMachine vm = trf.getVM_enviada();
             if (cliente.getCaminho().isEmpty()) {
                 // trecho dbg
-                if (this.maquinasVirtuais.contains(vm)) {
-                } else {
+                if (!this.maquinasVirtuais.contains(vm)) {
                     this.maquinasVirtuais.add(vm); // adiciona na lista de
                     // maquinas virtuais
                     if (this.alocDisponivel) {

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -148,9 +148,7 @@ public class CloudMaster extends Processing implements VmMaster,
 
     @Override
     public void clientExit (final Simulation simulacao, final GridTask cliente) {
-        System.out.println("Evento de Saída: VMM " + this.id());
-        if (cliente instanceof final CloudTask trf) {
-            System.out.println("cliente é a vm " + trf.getVM_enviada().id());
+        if (cliente instanceof CloudTask) {
             final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
@@ -167,7 +165,6 @@ public class CloudMaster extends Processing implements VmMaster,
                 }
             }
         } else {
-            System.out.println("cliente é uma tarefa " + cliente.getIdentificador());
             final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -62,10 +62,8 @@ public class CloudMaster extends Processing implements VmMaster,
         if (cliente instanceof final CloudTask trf) {
             final var vm = trf.getVM_enviada();
             if (cliente.getCaminho().isEmpty()) {
-                // trecho dbg
                 if (!this.maquinasVirtuais.contains(vm)) {
-                    this.maquinasVirtuais.add(vm); // adiciona na lista de
-                    // maquinas virtuais
+                    this.maquinasVirtuais.add(vm);
                     if (this.alocDisponivel) {
                         this.alocDisponivel = false;
                         this.alocadorVM.addVM(vm);

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -60,7 +60,7 @@ public class CloudMaster extends Processing implements VmMaster,
     @Override
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
         if (cliente instanceof final CloudTask trf) {
-            final VirtualMachine vm = trf.getVM_enviada();
+            final var vm = trf.getVM_enviada();
             if (cliente.getCaminho().isEmpty()) {
                 // trecho dbg
                 if (!this.maquinasVirtuais.contains(vm)) {
@@ -77,7 +77,7 @@ public class CloudMaster extends Processing implements VmMaster,
                     }
                 }
             } else {// se não for ele a origem ele precisa encaminhá-la
-                final Event evtFut = new Event(
+                final var evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.ARRIVAL,
                     cliente.getCaminho().remove(0),
@@ -94,7 +94,7 @@ public class CloudMaster extends Processing implements VmMaster,
                     if (!cliente.getOrigem().equals(this)) {
                         // encaminhar tarefa!
                         // Gera evento para chegada da tarefa no proximo servidor
-                        final Event evtFut = new Event(
+                        final var evtFut = new Event(
                             simulacao.getTime(this),
                             EventType.ARRIVAL,
                             cliente.getCaminho().remove(0),
@@ -117,7 +117,7 @@ public class CloudMaster extends Processing implements VmMaster,
                 } // Caso a tarefa está chegando pra ser escalonada
                 else {
                     if (cliente.getCaminho() != null) {
-                        final Event evtFut = new Event(
+                        final var evtFut = new Event(
                             simulacao.getTime(this),
                             EventType.ARRIVAL,
                             cliente.getCaminho().remove(0),
@@ -153,7 +153,7 @@ public class CloudMaster extends Processing implements VmMaster,
         System.out.println("Evento de Saída: VMM " + this.id());
         if (cliente instanceof final CloudTask trf) {
             System.out.println("cliente é a vm " + trf.getVM_enviada().id());
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
                 cliente.getCaminho().remove(0),
@@ -170,7 +170,7 @@ public class CloudMaster extends Processing implements VmMaster,
             }
         } else {
             System.out.println("cliente é uma tarefa " + cliente.getIdentificador());
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
                 cliente.getCaminho().remove(0),
@@ -256,14 +256,14 @@ public class CloudMaster extends Processing implements VmMaster,
         final List<Service> caminho = new ArrayList<>(Objects.requireNonNull(
             Processing.getMenorCaminhoIndireto(this, (Processing) request.getOrigem())
         ));
-        final Request novaRequest = new Request(
+        final var novaRequest = new Request(
             this, request.getTamComunicacao(), RequestType.UPDATE_RESULT
         );
         // Obtem informações dinâmicas
         novaRequest.setFilaEscravo(new ArrayList<>(this.filaTarefas));
         novaRequest.getFilaEscravo().addAll(this.escalonador.getFilaTarefas());
         novaRequest.setCaminho(caminho);
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             simulacao.getTime(this),
             EventType.MESSAGE,
             novaRequest.getCaminho().remove(0),
@@ -287,9 +287,9 @@ public class CloudMaster extends Processing implements VmMaster,
     public void handleAllocationAck (final Simulation simulacao, final Request request) {
         // se este VMM for o de origem ele deve atender senão deve encaminhar a request para frente
         System.out.println("--------------------------------------");
-        final CloudTask      trf   = (CloudTask) request.getTarefa();
-        final VirtualMachine auxVM = trf.getVM_enviada();
-        final CloudMachine   auxMaq = auxVM.getMaquinaHospedeira();
+        final var trf    = (CloudTask) request.getTarefa();
+        final var auxVM  = trf.getVM_enviada();
+        final var auxMaq = auxVM.getMaquinaHospedeira();
         System.out.println("Atendendo ACK de alocação da vm "
                            + auxVM.id()
                            + " na máquina "
@@ -298,7 +298,7 @@ public class CloudMaster extends Processing implements VmMaster,
             // se o VMM responsável da VM for este.. tratar o ack
             // primeiro encontrar o caminho pra máquina onde a vm está alocada
 
-            final int index = this.alocadorVM.getEscravos().indexOf(auxMaq);
+            final var index = this.alocadorVM.getEscravos().indexOf(auxMaq);
             // busca índice da maquina na lista de máquinas físicas do vmm
             final ArrayList<Service> caminho;
             if (index == -1) {
@@ -329,7 +329,7 @@ public class CloudMaster extends Processing implements VmMaster,
                 + " caminho intermediário para "
                 + auxVM.id());
             if (this.escalonador.getEscravos().contains(auxVM)) {
-                final int index =
+                final var index =
                     this.alocadorVM.getEscravos().indexOf(auxMaq);
                 final ArrayList<Service> caminho;
                 if (index == -1) {
@@ -344,7 +344,7 @@ public class CloudMaster extends Processing implements VmMaster,
                                    + caminho.size());
                 this.determinarCaminhoVM(auxVM, caminho);
             }
-            final Event evt = new Event(
+            final var evt = new Event(
                 simulacao.getTime(this),
                 EventType.MESSAGE,
                 request.getCaminho().remove(0),
@@ -366,7 +366,7 @@ public class CloudMaster extends Processing implements VmMaster,
 
     @Override
     public void executeAllocation () {
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             this.simulacao.getTime(this), EventType.ALLOCATION, this, null
         );
         // Event adicionado a lista de evntos futuros
@@ -386,7 +386,7 @@ public class CloudMaster extends Processing implements VmMaster,
     @Override
     public void executeScheduling () {
         System.out.println(this.id() + " solicitando escalonamento");
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             this.simulacao.getTime(this), EventType.SCHEDULING, this, null
         );
         // Event adicionado a lista de evntos futuros
@@ -405,7 +405,7 @@ public class CloudMaster extends Processing implements VmMaster,
             "Tarefa:" + task.getIdentificador() + "escalonada para vm:" + task
                 .getLocalProcessamento()
                 .id());
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             this.simulacao.getTime(this), EventType.EXIT, this, task
         );
         // Event adicionado a lista de evntos futuros
@@ -414,7 +414,7 @@ public class CloudMaster extends Processing implements VmMaster,
 
     @Override
     public GridTask cloneTask (final GridTask task) {
-        final GridTask tarefa = new GridTask(task);
+        final var tarefa = new GridTask(task);
         this.simulacao.addJob(tarefa);
         return tarefa;
     }
@@ -425,9 +425,9 @@ public class CloudMaster extends Processing implements VmMaster,
         final Processing slave,
         final RequestType requestType
     ) {
-        final Request msg = new Request(this, requestType, task);
+        final var msg = new Request(this, requestType, task);
         msg.setCaminho(this.escalonador.escalonarRota(slave));
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             this.simulacao.getTime(this), EventType.MESSAGE, msg.getCaminho().remove(0), msg
         );
         // Event adicionado a lista de evntos futuros
@@ -443,9 +443,9 @@ public class CloudMaster extends Processing implements VmMaster,
     public void sendVm (final VirtualMachine vm) {
         System.out.println("Enviar VM: alocando VM " + vm.id());
         System.out.println("------------------------------------------");
-        final CloudTask tarefa = new CloudTask(vm.getVmmResponsavel(), vm, 300.0, 0.0);
+        final var tarefa = new CloudTask(vm.getVmmResponsavel(), vm, 300.0, 0.0);
         tarefa.setCaminho(vm.getCaminho());
-        final Event evtFut =
+        final var evtFut =
             new Event(this.simulacao.getTime(this), EventType.EXIT, this, tarefa);
         // Event adicionado a lista de evntos futuros
         this.simulacao.addFutureEvent(evtFut);
@@ -472,11 +472,11 @@ public class CloudMaster extends Processing implements VmMaster,
         final var escravos = this.alocadorVM.getEscravos();
         this.caminhoEscravo = new ArrayList<>(escravos.size());
         // Busca pelo melhor caminho
-        for (int i = 0; i < escravos.size(); i++) {
+        for (var i = 0; i < escravos.size(); i++) {
             this.caminhoEscravo.add(i, Processing.getMenorCaminho(this, escravos.get(i)));
         }
         // verifica se todos os escravos são alcansaveis
-        for (int i = 0; i < escravos.size(); i++) {
+        for (var i = 0; i < escravos.size(); i++) {
             if (this.caminhoEscravo.get(i).isEmpty()) {
                 throw new LinkageError();
             }
@@ -489,7 +489,7 @@ public class CloudMaster extends Processing implements VmMaster,
         final Processing vm,
         final List<Service> caminhoVM
     ) {
-        final int indVM = this.escalonador.getEscravos().indexOf(vm);
+        final var indVM = this.escalonador.getEscravos().indexOf(vm);
         System.out.println("indice da vm: " + indVM);
         if (indVM >= this.caminhoVMs.size()) {
             this.caminhoVMs.add(indVM, caminhoVM);
@@ -497,7 +497,7 @@ public class CloudMaster extends Processing implements VmMaster,
             this.caminhoVMs.set(indVM, caminhoVM);
         }
         System.out.println("Lista atualizada de caminho para as vms:");
-        for (int i = 0; i < this.caminhoVMs.size(); i++) {
+        for (var i = 0; i < this.caminhoVMs.size(); i++) {
             System.out.println(this.escalonador.getEscravos().get(i).id());
             System.out.println(this.caminhoVMs.get(i).toString());
         }
@@ -529,7 +529,7 @@ public class CloudMaster extends Processing implements VmMaster,
 
     public void instanciarCaminhosVMs () {
         this.caminhoVMs = new ArrayList<>(this.escalonador.getEscravos().size());
-        for (int i = 0; i < this.escalonador.getEscravos().size(); i++) {
+        for (var i = 0; i < this.escalonador.getEscravos().size(); i++) {
             this.caminhoVMs.add(i, new ArrayList());
         }
     }

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -364,7 +364,6 @@ public class CloudMaster extends Processing implements VmMaster,
 
     @Override
     public void executeScheduling () {
-        System.out.println(this.id() + " solicitando escalonamento");
         final var evtFut = new Event(
             this.simulacao.getTime(this), EventType.SCHEDULING, this, null
         );
@@ -380,10 +379,6 @@ public class CloudMaster extends Processing implements VmMaster,
     @Override
     public void sendTask (final GridTask task) {
         // Gera evento para atender proximo cliente da lista
-        System.out.println(
-            "Tarefa:" + task.getIdentificador() + "escalonada para vm:" + task
-                .getLocalProcessamento()
-                .id());
         final var evtFut = new Event(
             this.simulacao.getTime(this), EventType.EXIT, this, task
         );
@@ -420,8 +415,6 @@ public class CloudMaster extends Processing implements VmMaster,
 
     @Override
     public void sendVm (final VirtualMachine vm) {
-        System.out.println("Enviar VM: alocando VM " + vm.id());
-        System.out.println("------------------------------------------");
         final var tarefa = new CloudTask(vm.getVmmResponsavel(), vm, 300.0, 0.0);
         tarefa.setCaminho(vm.getCaminho());
         final var evtFut =

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -462,19 +462,13 @@ public class CloudMaster extends Processing implements VmMaster,
         final List<Service> caminhoVM
     ) {
         final var indVM = this.escalonador.getEscravos().indexOf(vm);
-        System.out.println("indice da vm: " + indVM);
         if (indVM >= this.caminhoVMs.size()) {
             this.caminhoVMs.add(indVM, caminhoVM);
         } else {
             this.caminhoVMs.set(indVM, caminhoVM);
         }
-        System.out.println("Lista atualizada de caminho para as vms:");
-        for (var i = 0; i < this.caminhoVMs.size(); i++) {
-            System.out.println(this.escalonador.getEscravos().get(i).id());
-            System.out.println(this.caminhoVMs.get(i).toString());
-        }
+
         this.escalonador.setCaminhoEscravo(this.caminhoVMs);
-        System.out.println("------------------------------");
     }
 
     public CloudSchedulingPolicy getEscalonador () {

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -192,10 +192,8 @@ public class CloudMaster extends Processing implements VmMaster,
         final EventType tipo
     ) {
         if (tipo == EventType.SCHEDULING) {
-            System.out.println("Iniciando escalonamento...");
             this.escalonador.escalonar();
         } else if (tipo == EventType.ALLOCATION) {
-            System.out.println("Iniciando Alocação...");
             this.alocadorVM.escalonar();// realizar a rotina de alocar a máquina virtual
         } else if (request != null) {
             if (request.getTipo() == RequestType.UPDATE) {

--- a/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/CloudMaster.java
@@ -59,22 +59,12 @@ public class CloudMaster extends Processing implements VmMaster,
 
     @Override
     public void clientEnter (final Simulation simulacao, final GridTask cliente) {
-        System.out.println("------------------------------------------");
-        System.out.println("Evento de chegada no vmm " + this.id());
         if (cliente instanceof final CloudTask trf) {
             final VirtualMachine vm = trf.getVM_enviada();
             if (cliente.getCaminho().isEmpty()) {
                 // trecho dbg
                 if (this.maquinasVirtuais.contains(vm)) {
-                    System.out.println("VM duplicada");
-                    System.out.println("------------------------------------------");
                 } else {
-                    System.out.println("vm "
-                                       + vm.id()
-                                       + " adicionada no "
-                                       + "alocador do VMM "
-                                       + this.id());
-                    System.out.println("------------------------------------------");
                     this.maquinasVirtuais.add(vm); // adiciona na lista de
                     // maquinas virtuais
                     if (this.alocDisponivel) {
@@ -88,10 +78,6 @@ public class CloudMaster extends Processing implements VmMaster,
                     }
                 }
             } else {// se não for ele a origem ele precisa encaminhá-la
-                System.out.println(this.id()
-                                   + ": sou VMM intermediario, "
-                                   + "encamininhando "
-                                   + vm.id());
                 final Event evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.ARRIVAL,
@@ -101,17 +87,10 @@ public class CloudMaster extends Processing implements VmMaster,
                 simulacao.addFutureEvent(evtFut);
             }
         } else { // cliente é tarefa comum
-            System.out.println(
-                "cliente é a tarefa "
-                + cliente.getIdentificador()
-                + " com status "
-                + cliente.getEstado());
-
             if (cliente.getEstado() != TaskState.CANCELLED) {
                 // Tarefas concluida possuem tratamento diferencial
                 if (cliente.getEstado() == TaskState.DONE) {
-                    System.out.println("cliente é o retorno de tarefa "
-                                       + cliente.getIdentificador());
+
                     // se não for origem da tarefa ela deve ser encaminhada
                     if (!cliente.getOrigem().equals(this)) {
                         // encaminhar tarefa!
@@ -126,9 +105,7 @@ public class CloudMaster extends Processing implements VmMaster,
                         simulacao.addFutureEvent(evtFut);
                     }
                     // caso seja este o centro de serviço de origem
-                    System.out.println("Tarefa "
-                                       + cliente.getIdentificador()
-                                       + " adicionada na lista de concluídas");
+
                     this.escalonador.addTarefaConcluida(cliente);
 
                     if (this.tipoEscalonamento.contains(Condition.WHEN_RECEIVES_RESULT)) {
@@ -150,10 +127,7 @@ public class CloudMaster extends Processing implements VmMaster,
                         simulacao.addFutureEvent(evtFut);
                     } else {
                         if (this.escDisponivel) {
-                            System.out.println(
-                                "Tarefa "
-                                + cliente.getIdentificador()
-                                + " chegando para ser escalonada");
+
                             this.escDisponivel = false;
                             // escalonador adiciona nova tarefa
                             this.escalonador.adicionarTarefa(cliente);

--- a/src/main/java/ispd/motor/queues/centers/impl/Link.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/Link.java
@@ -43,10 +43,6 @@ public class Link extends Communication {
     @Override
     public void clientProcessing (final Simulation simulacao, final GridTask cliente) {
         if (!this.conexoesSaida.equals(cliente.getCaminho().get(0))) {
-            System.out.println(
-                "link " + this.id() + " tarefa " + cliente.getIdentificador() + " tempo " +
-                simulacao.getTime(this) + " local " + cliente.getCaminho().get(0).id()
-            );
             throw new IllegalArgumentException(
                 "O destino da mensagem é um recurso sem conexão com este link");
         } else {

--- a/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
@@ -68,7 +68,7 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 //indica que recurso está ocupado
                 this.processadoresDisponiveis--;
                 //cria evento para iniciar o atendimento imediatamente
-                final Event novoEvt = new Event(
+                final var novoEvt = new Event(
                     simulacao.getTime(this), EventType.SERVICE, this, cliente
                 );
                 simulacao.addFutureEvent(novoEvt);
@@ -87,18 +87,18 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                             + this.tempoProcessar(cliente.getTamProcessamento()
                                                   - cliente.getMflopsProcessado());
         if (!this.falhas.isEmpty() && next > this.falhas.get(0)) {
-            Double tFalha = this.falhas.remove(0);
+            var tFalha = this.falhas.remove(0);
             if (tFalha < simulacao.getTime(this)) {
                 tFalha = simulacao.getTime(this);
             }
-            final Request msg = new Request(this, RequestType.FAILURE, cliente);
-            final Event evt = new Event(
+            final var msg = new Request(this, RequestType.FAILURE, cliente);
+            final var evt = new Event(
                 tFalha, EventType.MESSAGE, this, msg
             );
             simulacao.addFutureEvent(evt);
         } else {
             //Gera evento para atender proximo cliente da lista
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 next, EventType.EXIT, this, cliente
             );
             //Event adicionado a lista de evntos futuros
@@ -113,7 +113,7 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
             .getMetrica()
             .incMflopsProcessados(cliente.getTamProcessamento() - cliente.getMflopsProcessado());
         //Incrementa o tempo de processamento
-        final double tempoProc =
+        final var tempoProc =
             this.tempoProcessar(cliente.getTamProcessamento() - cliente.getMflopsProcessado());
         this.getMetrica().incSegundosDeProcessamento(tempoProc);
         //Incrementa o tempo de transmissão no pacote
@@ -123,23 +123,23 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
         cliente.calcEficiencia(this.getPoderComputacional());
         //Devolve tarefa para o mestre
 
-        final Service            Origem = cliente.getOrigem();
+        final var Origem = cliente.getOrigem();
         final ArrayList<Service> caminho;
         if (Origem.equals(this.vmmResponsavel)) {
             caminho = new ArrayList<>(this.caminhoVMM);
         } else {
             System.out.println("A tarefa não saiu do vmm desta vm!!!!!");
-            final int index = this.VMMsIntermediarios.indexOf((CloudMaster) Origem);
+            final var index = this.VMMsIntermediarios.indexOf((CloudMaster) Origem);
             if (index == -1) {
-                final CloudMachine auxMaq = this.maquinaHospedeira;
-                final ArrayList<Service> caminhoInter =
-                    new ArrayList<>(getMenorCaminhoIndiretoCloud(
+                final var auxMaq = this.maquinaHospedeira;
+                final var caminhoInter =
+                    new ArrayList<Service>(getMenorCaminhoIndiretoCloud(
                         auxMaq,
                         (Processing) Origem
                     ));
                 caminho = new ArrayList<>(caminhoInter);
                 this.VMMsIntermediarios.add((CloudMaster) Origem);
-                final int idx = this.VMMsIntermediarios.indexOf((CloudMaster) Origem);
+                final var idx = this.VMMsIntermediarios.indexOf((CloudMaster) Origem);
                 this.caminhoIntermediarios.add(idx, caminhoInter);
             } else {
                 caminho = new ArrayList<Service>(this.caminhoIntermediarios.get(index));
@@ -149,7 +149,7 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
         System.out.println("Saida -" + this.id() + "- caminho size:" + caminho.size());
 
         //Gera evento para chegada da tarefa no proximo servidor
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             simulacao.getTime(this),
             EventType.ARRIVAL,
             cliente.getCaminho().remove(0),
@@ -163,8 +163,8 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
             this.processadoresDisponiveis++;
         } else {
             //Gera evento para atender proximo cliente da lista
-            final GridTask proxCliente = this.filaTarefas.remove(0);
-            final Event NovoEvt = new Event(
+            final var proxCliente = this.filaTarefas.remove(0);
+            final var NovoEvt = new Event(
                 simulacao.getTime(this), EventType.SERVICE, this, proxCliente
             );
             //Event adicionado a lista de evntos futuros
@@ -210,9 +210,9 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
 
     @Override
     public void handleReturn (final Simulation simulacao, final Request request) {
-        final boolean remover = this.filaTarefas.remove(request.getTarefa());
+        final var remover = this.filaTarefas.remove(request.getTarefa());
         if (remover) {
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
                 request.getTarefa().getOrigem(),
@@ -235,8 +235,8 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 this.processadoresDisponiveis++;
             } else {
                 //Gera evento para atender proximo cliente da lista
-                final GridTask proxCliente = this.filaTarefas.remove(0);
-                final Event evtFut = new Event(
+                final var proxCliente = this.filaTarefas.remove(0);
+                final var evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.SERVICE,
                     this, proxCliente
@@ -245,9 +245,9 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 simulacao.addFutureEvent(evtFut);
             }
         }
-        final double inicioAtendimento = request.getTarefa().cancelar(simulacao.getTime(this));
-        final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-        final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+        final var inicioAtendimento = request.getTarefa().cancelar(simulacao.getTime(this));
+        final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+        final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
         //Incrementa o número de Mflops processados por este recurso
         this.getMetrica().incMflopsProcessados(mflopsProcessados);
         //Incrementa o tempo de processamento
@@ -260,13 +260,13 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
     public void handleUpdate (final Simulation simulacao, final Request request) {
         //enviar resultados
         final List<Service> caminho = new ArrayList<>(this.caminhoVMM);
-        final Request novaRequest =
+        final var novaRequest =
             new Request(this, request.getTamComunicacao(), RequestType.UPDATE_RESULT);
         //Obtem informações dinâmicas
         novaRequest.setProcessadorEscravo(new ArrayList<>(this.tarefaEmExecucao));
         novaRequest.setFilaEscravo(new ArrayList<>(this.filaTarefas));
         novaRequest.setCaminho(caminho);
-        final Event evtFut = new Event(
+        final var evtFut = new Event(
             simulacao.getTime(this),
             EventType.MESSAGE,
             novaRequest.getCaminho().remove(0),
@@ -284,18 +284,18 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
     @Override
     public void handleFailure (final Simulation simulacao, final Request request) {
         this.recuperacao.remove(0);
-        for (final GridTask tar : this.tarefaEmExecucao) {
+        for (final var tar : this.tarefaEmExecucao) {
             if (tar.getEstado() == TaskState.PROCESSING) {
-                final double inicioAtendimento = tar.parar(simulacao.getTime(this));
-                final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-                final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+                final var inicioAtendimento = tar.parar(simulacao.getTime(this));
+                final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+                final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
                 //Incrementa o número de Mflops processados por este recurso
                 this.getMetrica().incMflopsProcessados(mflopsProcessados);
                 //Incrementa o tempo de processamento
                 this.getMetrica().incSegundosDeProcessamento(tempoProc);
                 //Incrementa procentagem da tarefa processada
                 // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
-                final int numCP = (int) (mflopsProcessados / 0.0);
+                final var numCP = (int) (mflopsProcessados / 0.0);
                 // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
                 tar.setMflopsProcessado(numCP * 0.0);
                 tar.setEstado(TaskState.FAILED);
@@ -322,8 +322,8 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 this.processadoresDisponiveis++;
             } else {
                 //Gera evento para atender proximo cliente da lista
-                final GridTask proxCliente = this.filaTarefas.remove(0);
-                final Event evtFut = new Event(
+                final var proxCliente = this.filaTarefas.remove(0);
+                final var evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.SERVICE,
                     this, proxCliente
@@ -331,9 +331,9 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 //Event adicionado a lista de evntos futuros
                 simulacao.addFutureEvent(evtFut);
             }
-            final double inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
-            final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-            final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+            final var inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
+            final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+            final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
             //Incrementa o número de Mflops processados por este recurso
             this.getMetrica().incMflopsProcessados(mflopsProcessados);
             //Incrementa o tempo de processamento
@@ -347,7 +347,7 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
 
     @Override
     public void handleCancel (final Simulation simulacao, final Request request) {
-        boolean remover = false;
+        var remover = false;
         if (request.getTarefa().getEstado() == TaskState.BLOCKED) {
             remover = this.filaTarefas.remove(request.getTarefa());
         } else if (request.getTarefa().getEstado() == TaskState.PROCESSING) {
@@ -362,8 +362,8 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 this.processadoresDisponiveis++;
             } else {
                 //Gera evento para atender proximo cliente da lista
-                final GridTask proxCliente = this.filaTarefas.remove(0);
-                final Event evtFut = new Event(
+                final var proxCliente = this.filaTarefas.remove(0);
+                final var evtFut = new Event(
                     simulacao.getTime(this),
                     EventType.SERVICE,
                     this, proxCliente
@@ -371,22 +371,22 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
                 //Event adicionado a lista de evntos futuros
                 simulacao.addFutureEvent(evtFut);
             }
-            final double inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
-            final double tempoProc         = simulacao.getTime(this) - inicioAtendimento;
-            final double mflopsProcessados = this.getMflopsProcessados(tempoProc);
+            final var inicioAtendimento = request.getTarefa().parar(simulacao.getTime(this));
+            final var tempoProc         = simulacao.getTime(this) - inicioAtendimento;
+            final var mflopsProcessados = this.getMflopsProcessados(tempoProc);
             //Incrementa o número de Mflops processados por este recurso
             this.getMetrica().incMflopsProcessados(mflopsProcessados);
             //Incrementa o tempo de processamento
             this.getMetrica().incSegundosDeProcessamento(tempoProc);
             //Incrementa procentagem da tarefa processada
             // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
-            final int numCP = (int) (mflopsProcessados / 0.0);
+            final var numCP = (int) (mflopsProcessados / 0.0);
             // Se for alterado o tempo de checkpoint, alterar também no métricas linha 832, cálculo da energia desperdiçada
             request.getTarefa().setMflopsProcessado(numCP * 0.0);
             this.tarefaEmExecucao.remove(request.getTarefa());
         }
         if (remover) {
-            final Event evtFut = new Event(
+            final var evtFut = new Event(
                 simulacao.getTime(this),
                 EventType.ARRIVAL,
                 request.getTarefa().getOrigem(),

--- a/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
@@ -128,7 +128,6 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
         if (Origem.equals(this.vmmResponsavel)) {
             caminho = new ArrayList<>(this.caminhoVMM);
         } else {
-            System.out.println("A tarefa não saiu do vmm desta vm!!!!!");
             final var index = this.VMMsIntermediarios.indexOf((CloudMaster) Origem);
             if (index == -1) {
                 final var auxMaq = this.maquinaHospedeira;
@@ -146,7 +145,6 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
             }
         }
         cliente.setCaminho(caminho);
-        System.out.println("Saida -" + this.id() + "- caminho size:" + caminho.size());
 
         //Gera evento para chegada da tarefa no proximo servidor
         final var evtFut = new Event(

--- a/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
@@ -132,7 +132,7 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
             if (index == -1) {
                 final var auxMaq = this.maquinaHospedeira;
                 final var caminhoInter =
-                    new ArrayList<Service>(getMenorCaminhoIndiretoCloud(
+                    new ArrayList<>(getMenorCaminhoIndiretoCloud(
                         auxMaq,
                         (Processing) Origem
                     ));

--- a/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
@@ -83,8 +83,8 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
         cliente.finalizarEsperaProcessamento(simulacao.getTime(this));
         cliente.iniciarAtendimentoProcessamento(simulacao.getTime(this));
         this.tarefaEmExecucao.add(cliente);
-        final Double next = simulacao.getTime(this)
-                            + this.tempoProcessar(cliente.getTamProcessamento()
+        final var next = simulacao.getTime(this)
+                         + this.tempoProcessar(cliente.getTamProcessamento()
                                                   - cliente.getMflopsProcessado());
         if (!this.falhas.isEmpty() && next > this.falhas.get(0)) {
             var tFalha = this.falhas.remove(0);

--- a/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
+++ b/src/main/java/ispd/motor/queues/centers/impl/VirtualMachine.java
@@ -82,11 +82,6 @@ public class VirtualMachine extends Processing implements Client, RequestHandler
     public void clientProcessing (final Simulation simulacao, final GridTask cliente) {
         cliente.finalizarEsperaProcessamento(simulacao.getTime(this));
         cliente.iniciarAtendimentoProcessamento(simulacao.getTime(this));
-        if (cliente == null) {
-            System.out.println("cliente nao existe");
-        } else {
-            System.out.println("cliente é a tarefa " + cliente.getIdentificador());
-        }
         this.tarefaEmExecucao.add(cliente);
         final Double next = simulacao.getTime(this)
                             + this.tempoProcessar(cliente.getTamProcessamento()

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -80,10 +80,11 @@ public abstract class Simulation {
     }
 
     protected void initCloudAllocators () {
-        for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
-            final var master = (CloudMaster) genericMaster;
-            master.getAlocadorVM().iniciar();
-        }
+        this.cloudQueueNetwork
+            .getMestres()
+            .stream()
+            .map(CloudMaster.class::cast)
+            .forEach(master -> master.getAlocadorVM().iniciar());
     }
 
     protected void initCloudSchedulers () {

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -87,11 +87,15 @@ public abstract class Simulation {
             .forEach(Policy::iniciar);
     }
 
+    private static void initCloudMaster (final CloudMaster master) {
+        master.getEscalonador().iniciar();
+        master.instanciarCaminhosVMs();
+    }
+
     protected void initCloudSchedulers () {
         for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
             final var master = (CloudMaster) genericMaster;
-            master.getEscalonador().iniciar();
-            master.instanciarCaminhosVMs();
+            initCloudMaster(master);
         }
     }
 

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -93,10 +93,9 @@ public abstract class Simulation {
     }
 
     protected void initCloudSchedulers () {
-        for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
-            final var master = (CloudMaster) genericMaster;
-            initCloudMaster(master);
-        }
+        this.cloudQueueNetwork.getMestres().stream()
+            .map(CloudMaster.class::cast)
+            .forEach(Simulation::initCloudMaster);
     }
 
     public void createRouting () {

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -74,14 +74,14 @@ public abstract class Simulation {
     }
 
     protected void initSchedulers () {
-        for (final Processing master : this.queueNetwork.getMestres()) {
+        for (final var master : this.queueNetwork.getMestres()) {
             ((GridMaster) master).getEscalonador().iniciar();
         }
     }
 
     protected void initCloudAllocators () {
-        for (final Processing genericMaster : this.cloudQueueNetwork.getMestres()) {
-            final CloudMaster master = (CloudMaster) genericMaster;
+        for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
+            final var master = (CloudMaster) genericMaster;
             System.out.printf(
                 "VMM %s iniciando o alocador %s%n",
                 genericMaster.id(),
@@ -92,8 +92,8 @@ public abstract class Simulation {
     }
 
     protected void initCloudSchedulers () {
-        for (final Processing genericMaster : this.cloudQueueNetwork.getMestres()) {
-            final CloudMaster master = (CloudMaster) genericMaster;
+        for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
+            final var master = (CloudMaster) genericMaster;
             System.out.printf(
                 "VMM %s iniciando escalonador %s%n",
                 genericMaster.id(),
@@ -105,8 +105,8 @@ public abstract class Simulation {
     }
 
     public void createRouting () {
-        for (final Processing master : this.queueNetwork.getMestres()) {
-            final Simulable temp = (Simulable) master;
+        for (final var master : this.queueNetwork.getMestres()) {
+            final var temp = (Simulable) master;
 
             // Give access to the master of the queue of future events.
             temp.setSimulation(this);
@@ -118,14 +118,14 @@ public abstract class Simulation {
             this.window.println("The model has no processing slaves.", Color.orange);
         } else {
             // Find the shortest path between each slave and the master.
-            for (final GridMachine machine : this.queueNetwork.getMaquinas()) {
+            for (final var machine : this.queueNetwork.getMaquinas()) {
                 machine.determinarCaminhos();
             }
         }
     }
 
     public General getMetrics () {
-        final General metric = new General(this.queueNetwork, this.getTime(null), this.jobs);
+        final var metric = new General(this.queueNetwork, this.getTime(null), this.jobs);
 
         this.window.print("Getting Results.");
         this.window.print(" -> ");
@@ -143,7 +143,7 @@ public abstract class Simulation {
         this.window.print("Getting Results.");
         this.window.print(" -> ");
 
-        final General metric = new General(this.cloudQueueNetwork, this.getTime(null), this.jobs);
+        final var metric = new General(this.cloudQueueNetwork, this.getTime(null), this.jobs);
 
         this.window.incProgresso(5);
         this.window.println("OK", Color.green);

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -80,11 +80,10 @@ public abstract class Simulation {
     }
 
     protected void initCloudAllocators () {
-        this.cloudQueueNetwork
-            .getMestres()
-            .stream()
+        this.cloudQueueNetwork.getMestres().stream()
             .map(CloudMaster.class::cast)
-            .forEach(master -> master.getAlocadorVM().iniciar());
+            .map(CloudMaster::getAlocadorVM)
+            .forEach(Policy::iniciar);
     }
 
     protected void initCloudSchedulers () {

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -82,11 +82,6 @@ public abstract class Simulation {
     protected void initCloudAllocators () {
         for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
             final var master = (CloudMaster) genericMaster;
-            System.out.printf(
-                "VMM %s iniciando o alocador %s%n",
-                genericMaster.id(),
-                master.getAlocadorVM().toString()
-            );
             master.getAlocadorVM().iniciar();
         }
     }

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -90,11 +90,6 @@ public abstract class Simulation {
     protected void initCloudSchedulers () {
         for (final var genericMaster : this.cloudQueueNetwork.getMestres()) {
             final var master = (CloudMaster) genericMaster;
-            System.out.printf(
-                "VMM %s iniciando escalonador %s%n",
-                genericMaster.id(),
-                master.getEscalonador().toString()
-            );
             master.getEscalonador().iniciar();
             master.instanciarCaminhosVMs();
         }

--- a/src/main/java/ispd/motor/simul/Simulation.java
+++ b/src/main/java/ispd/motor/simul/Simulation.java
@@ -74,9 +74,10 @@ public abstract class Simulation {
     }
 
     protected void initSchedulers () {
-        for (final var master : this.queueNetwork.getMestres()) {
-            ((GridMaster) master).getEscalonador().iniciar();
-        }
+        this.queueNetwork.getMestres().stream()
+            .map(GridMaster.class::cast)
+            .map(GridMaster::getEscalonador)
+            .forEach(Policy::iniciar);
     }
 
     protected void initCloudAllocators () {

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -120,8 +120,7 @@ public class CloudSequential extends Simulation {
             if (selecionarFalhas.cbxEstado != null) {
                 window.println("There are injected State failures.");
                 window.println("Creating state fault.");
-                final State state = new State();
-                state.FIState1(window);
+                State.showMessage(window);
             } else {
                 window.println("There aren't injected State failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -78,7 +78,7 @@ public class CloudSequential extends Simulation {
                 window.println("There are injected hardware omission failures.");
                 window.println("Creating Hardware fault.");
                 final Hardware fihardware = new Hardware();
-                fihardware.showMessage(window, cloudQueueNetwork);
+                fihardware.showMessage(window);
             } else {
                 window.println("There aren't injected hardware omission failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -112,9 +112,7 @@ public class CloudSequential extends Simulation {
             if (selecionarFalhas.cbxValores != null) {
                 window.println("There are injected Values failures.");
                 window.println("Creating value fault.");
-                final Global global = new Global();
-                final Value  value  = new Value();
-                value.setFaults(window, cloudQueueNetwork, global);
+                Value.setFaults(window, cloudQueueNetwork, new Global());
             } else {
                 window.println("There aren't injected Value failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -88,7 +88,7 @@ public class CloudSequential extends Simulation {
                 window.println("Creating software fault.");
                 window.println("Software failure created.");
                 final Software fisoftdware = new Software();
-                fisoftdware.FISfotware1(window, cloudQueueNetwork);
+                fisoftdware.FISfotware1(window);
             } else {
                 window.println("There aren't injected software omission failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -261,7 +261,7 @@ public class CloudSequential extends Simulation {
         return this.time;
     }
 
-    public void addEventos (final List<GridTask> tarefas) {
+    private void addEventos (final List<GridTask> tarefas) {
         for (final GridTask tarefa : tarefas) {
             final var evt = new ispd.motor.Event(
                 tarefa.getTimeCriacao(),

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -121,7 +121,7 @@ public class CloudSequential extends Simulation {
                 window.println("There are injected State failures.");
                 window.println("Creating state fault.");
                 final State state = new State();
-                state.FIState1(window, cloudQueueNetwork);
+                state.FIState1(window);
             } else {
                 window.println("There aren't injected State failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -52,7 +52,6 @@ public class CloudSequential extends Simulation {
         window.print("Creating routing.");
         window.print(" -> ");
 
-        System.out.println("---------------------------------------");
         for (final Processing mst : cloudQueueNetwork.getMestres()) {
             final Simulable temp = (Simulable) mst;
             final Simulable aux  = (Simulable) mst;
@@ -60,7 +59,6 @@ public class CloudSequential extends Simulation {
             aux.setSimulation(this);
             temp.setSimulation(this);
             //Encontra menor caminho entre o mestre e seus escravos
-            System.out.printf("Mestre %s encontrando seus escravos\n", mst.id());
             mst.determinarCaminhos(); //mestre encontra caminho para seus escravos
         }
 
@@ -204,7 +202,6 @@ public class CloudSequential extends Simulation {
             .isEmpty()) {
             window.println("The model has no phisical machines.", Color.orange);
         } else {
-            System.out.println("---------------------------------------");
             for (final CloudMachine maq : cloudQueueNetwork.getMaquinasCloud()) {
                 // Encontra menor caminho entre o escravo e seu mestre
                 maq.determinarCaminhos(); // escravo encontra caminhos para seu mestre
@@ -218,14 +215,10 @@ public class CloudSequential extends Simulation {
     @Override
     public void simulate () {
         //inicia os escalonadores
-        System.out.println("---------------------------------------");
         this.initCloudSchedulers();
-        System.out.println("---------------------------------------");
-
         this.initCloudAllocators();
-        System.out.println("---------------------------------------");
+
         this.addEventos(this.getJobs());
-        System.out.println("---------------------------------------");
 
         if (this.atualizarEscalonadores()) {
             this.realizarSimulacaoAtualizaTime();
@@ -269,7 +262,6 @@ public class CloudSequential extends Simulation {
     }
 
     public void addEventos (final List<GridTask> tarefas) {
-        System.out.println("Tarefas sendo adicionadas na lista de eventos futuros");
         for (final GridTask tarefa : tarefas) {
             final var evt = new ispd.motor.Event(
                 tarefa.getTimeCriacao(),

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -87,8 +87,7 @@ public class CloudSequential extends Simulation {
                 window.println("There are injected software omission failures.");
                 window.println("Creating software fault.");
                 window.println("Software failure created.");
-                final Software fisoftdware = new Software();
-                fisoftdware.showMessage(window);
+                Software.showMessage(window);
             } else {
                 window.println("There aren't injected software omission failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -78,7 +78,7 @@ public class CloudSequential extends Simulation {
                 window.println("There are injected hardware omission failures.");
                 window.println("Creating Hardware fault.");
                 final Hardware fihardware = new Hardware();
-                fihardware.showMessage(window);
+                Hardware.showMessage(window);
             } else {
                 window.println("There aren't injected hardware omission failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -1,7 +1,6 @@
 package ispd.motor.simul.impl;
 
 import ispd.gui.*;
-import ispd.motor.Event;
 import ispd.motor.*;
 import ispd.motor.faults.*;
 import ispd.motor.metrics.*;
@@ -52,9 +51,9 @@ public class CloudSequential extends Simulation {
         window.print("Creating routing.");
         window.print(" -> ");
 
-        for (final Processing mst : cloudQueueNetwork.getMestres()) {
-            final Simulable temp = (Simulable) mst;
-            final Simulable aux  = (Simulable) mst;
+        for (final var mst : cloudQueueNetwork.getMestres()) {
+            final var temp = (Simulable) mst;
+            final var aux  = (Simulable) mst;
             //Cede acesso ao mestre a fila de eventos futuros
             aux.setSimulation(this);
             temp.setSimulation(this);
@@ -202,7 +201,7 @@ public class CloudSequential extends Simulation {
             .isEmpty()) {
             window.println("The model has no phisical machines.", Color.orange);
         } else {
-            for (final CloudMachine maq : cloudQueueNetwork.getMaquinasCloud()) {
+            for (final var maq : cloudQueueNetwork.getMaquinasCloud()) {
                 // Encontra menor caminho entre o escravo e seu mestre
                 maq.determinarCaminhos(); // escravo encontra caminhos para seu mestre
             }
@@ -245,7 +244,7 @@ public class CloudSequential extends Simulation {
         // remover evento de saida do cliente do servidor
         final var interator = this.eventos.iterator();
         while (interator.hasNext()) {
-            final ispd.motor.Event ev = interator.next();
+            final var ev = interator.next();
             if (ev.getType() == eventType
                 && ev.getServidor().equals(eventServer)
                 && ev.getClient().equals(eventClient)) {
@@ -262,7 +261,7 @@ public class CloudSequential extends Simulation {
     }
 
     private void addEventos (final List<GridTask> tarefas) {
-        for (final GridTask tarefa : tarefas) {
+        for (final var tarefa : tarefas) {
             final var evt = new ispd.motor.Event(
                 tarefa.getTimeCriacao(),
                 EventType.ARRIVAL,
@@ -274,8 +273,8 @@ public class CloudSequential extends Simulation {
     }
 
     private boolean atualizarEscalonadores () {
-        for (final Processing mst : this.getCloudQueueNetwork().getMestres()) {
-            final CloudMaster mestre = (CloudMaster) mst;
+        for (final var mst : this.getCloudQueueNetwork().getMestres()) {
+            final var mestre = (CloudMaster) mst;
             if (mestre.getEscalonador().getTempoAtualizar() != null) {
                 return true;
             }
@@ -295,12 +294,12 @@ public class CloudSequential extends Simulation {
             //executa estes eventos de acordo com sua ordem de chegada
             //de forma a evitar a execução de um evento antes de outro
             //que seria criado anteriormente
-            for (final Object[] ob : updateArray) {
+            for (final var ob : updateArray) {
                 final var event = this.eventos.peek();
                 Objects.requireNonNull(event);
                 if ((Double) ob[2] < event.getCreationTime()) {
-                    final GridMaster mestre = (GridMaster) ob[0];
-                    for (final Processing maq : mestre.getEscalonador().getEscravos()) {
+                    final var mestre = (GridMaster) ob[0];
+                    for (final var maq : mestre.getEscalonador().getEscravos()) {
                         mestre.atualizar(maq, (Double) ob[2]);
                     }
                     ob[2] = (Double) ob[2] + (Double) ob[1];
@@ -321,7 +320,7 @@ public class CloudSequential extends Simulation {
     }
 
     private void desligarMaquinas (final Simulation simulation, final CloudQueueNetwork qn) {
-        for (final CloudMachine aux : qn.getMaquinasCloud()) {
+        for (final var aux : qn.getMaquinasCloud()) {
             aux.desligar(simulation);
         }
     }
@@ -339,7 +338,7 @@ public class CloudSequential extends Simulation {
     }
 
     private void processTopEvent () {
-        final Event eventoAtual = this.eventos.poll();
+        final var eventoAtual = this.eventos.poll();
         Objects.requireNonNull(eventoAtual);
         this.time = eventoAtual.getCreationTime();
         switch (eventoAtual.getType()) {

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -114,7 +114,7 @@ public class CloudSequential extends Simulation {
                 window.println("Creating value fault.");
                 final Global global = new Global();
                 final Value  value  = new Value();
-                value.FIValue1(window, cloudQueueNetwork, global);
+                value.setFaults(window, cloudQueueNetwork, global);
             } else {
                 window.println("There aren't injected Value failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -88,7 +88,7 @@ public class CloudSequential extends Simulation {
                 window.println("Creating software fault.");
                 window.println("Software failure created.");
                 final Software fisoftdware = new Software();
-                fisoftdware.FISfotware1(window);
+                fisoftdware.showMessage(window);
             } else {
                 window.println("There aren't injected software omission failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -77,7 +77,6 @@ public class CloudSequential extends Simulation {
             if (selecionarFalhas.cbkOmissaoHardware != null) {
                 window.println("There are injected hardware omission failures.");
                 window.println("Creating Hardware fault.");
-                final Hardware fihardware = new Hardware();
                 Hardware.showMessage(window);
             } else {
                 window.println("There aren't injected hardware omission failures.");

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -78,7 +78,7 @@ public class CloudSequential extends Simulation {
                 window.println("There are injected hardware omission failures.");
                 window.println("Creating Hardware fault.");
                 final Hardware fihardware = new Hardware();
-                fihardware.FIHardware1(window, cloudQueueNetwork);
+                fihardware.showMessage(window, cloudQueueNetwork);
             } else {
                 window.println("There aren't injected hardware omission failures.");
             }

--- a/src/main/java/ispd/motor/simul/impl/CloudSequential.java
+++ b/src/main/java/ispd/motor/simul/impl/CloudSequential.java
@@ -1,6 +1,7 @@
 package ispd.motor.simul.impl;
 
 import ispd.gui.*;
+import ispd.motor.Event;
 import ispd.motor.*;
 import ispd.motor.faults.*;
 import ispd.motor.metrics.*;
@@ -18,7 +19,7 @@ import java.util.stream.*;
 
 public class CloudSequential extends Simulation {
 
-    private final PriorityQueue<ispd.motor.Event> eventos = new PriorityQueue<>();
+    private final PriorityQueue<Event> eventos = new PriorityQueue<>();
 
     private double time = 0;
 
@@ -231,7 +232,7 @@ public class CloudSequential extends Simulation {
     }
 
     @Override
-    public void addFutureEvent (final ispd.motor.Event ev) {
+    public void addFutureEvent (final Event ev) {
         this.eventos.offer(ev);
     }
 
@@ -262,7 +263,7 @@ public class CloudSequential extends Simulation {
 
     private void addEventos (final List<GridTask> tarefas) {
         for (final var tarefa : tarefas) {
-            final var evt = new ispd.motor.Event(
+            final var evt = new Event(
                 tarefa.getTimeCriacao(),
                 EventType.ARRIVAL,
                 tarefa.getOrigem(),

--- a/src/main/java/ispd/motor/simul/impl/Parallel.java
+++ b/src/main/java/ispd/motor/simul/impl/Parallel.java
@@ -118,11 +118,7 @@ public class Parallel extends Simulation {
 
     @Override
     public void addFutureEvent (final Event ev) {
-        if (ev.getType() == EventType.ARRIVAL) {
-            this.threadFilaEventos.get(ev.getServidor()).offer(ev);
-        } else {
-            this.threadFilaEventos.get(ev.getServidor()).offer(ev);
-        }
+        this.threadFilaEventos.get(ev.getServidor()).offer(ev);
     }
 
     @Override

--- a/src/main/java/ispd/motor/simul/impl/Parallel.java
+++ b/src/main/java/ispd/motor/simul/impl/Parallel.java
@@ -54,7 +54,7 @@ public class Parallel extends Simulation {
             }
         }
 
-        for (final Service rec : this.recursos) {
+        for (final var rec : this.recursos) {
             this.threadFilaEventos.put(rec, new PriorityBlockingQueue<>());
             this.threadTrabalhador.put(rec, new ThreadTrabalhador(rec, this));
         }
@@ -94,10 +94,10 @@ public class Parallel extends Simulation {
 
         Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
         // Realizar a simulação
-        boolean fim = false;
+        var fim = false;
         while (!fim) {
             fim = true;
-            for (final Service rec : this.recursos) {
+            for (final var rec : this.recursos) {
                 if (!this.threadFilaEventos.get(rec).isEmpty()
                     && !this.threadTrabalhador.get(rec).executando) {
                     this.threadTrabalhador.get(rec).executando = true;
@@ -149,7 +149,7 @@ public class Parallel extends Simulation {
             return this.threadTrabalhador.get(origin).getRelogioLocal();
         } else {
             double val = 0;
-            for (final Service rec : this.recursos) {
+            for (final var rec : this.recursos) {
                 if (this.threadTrabalhador.get(rec).getRelogioLocal() > val) {
                     val = this.threadTrabalhador.get(rec).getRelogioLocal();
                 }
@@ -160,8 +160,8 @@ public class Parallel extends Simulation {
 
     @Override
     public void createRouting () {
-        for (final Processing mst : this.getQueueNetwork().getMestres()) {
-            final Simulable temp = (Simulable) mst;
+        for (final var mst : this.getQueueNetwork().getMestres()) {
+            final var temp = (Simulable) mst;
             //Cede acesso ao mestre a fila de eventos futuros
             temp.setSimulation(this);
             //Encontra menor caminho entre o mestre e seus escravos
@@ -173,7 +173,7 @@ public class Parallel extends Simulation {
             .isEmpty()) {
             this.getWindow().println("The model has no processing slaves.", Color.orange);
         } else {
-            for (final GridMachine maq : this.getQueueNetwork().getMaquinas()) {
+            for (final var maq : this.getQueueNetwork().getMaquinas()) {
                 //Encontra menor caminho entre o escravo e seu mestre
                 this.threadPool.execute(new determinarCaminho(maq));
             }
@@ -218,7 +218,7 @@ public class Parallel extends Simulation {
             synchronized (this) {
                 while (!Parallel.this.threadFilaEventos.get(this.recurso).isEmpty()) {
                     // Verificando ocorencia de erro
-                    final ispd.motor.Event eventoAtual =
+                    final var eventoAtual =
                         Parallel.this.threadFilaEventos.get(this.recurso).poll();
                     if (eventoAtual.getCreationTime() > this.relogioLocal) {
                         this.relogioLocal = eventoAtual.getCreationTime();
@@ -306,15 +306,15 @@ public class Parallel extends Simulation {
                             .get(this.getRecurso())
                             .peek()
                             .getCreationTime()) {
-                        final GridMaster mestre = (GridMaster) this.item[0];
-                        for (final Processing maq :
+                        final var mestre = (GridMaster) this.item[0];
+                        for (final var maq :
                             mestre.getEscalonador().getEscravos()) {
                             mestre.atualizar(maq, (Double) this.item[2]);
                         }
                         this.item[2] =
                             (Double) this.item[2] + (Double) this.item[1];
                     }
-                    final ispd.motor.Event eventoAtual =
+                    final var eventoAtual =
                         Parallel.this.threadFilaEventos.get(this.getRecurso()).poll();
                     if (eventoAtual.getCreationTime() > this.getRelogioLocal()) {
                         this.setRelogioLocal(eventoAtual.getCreationTime());
@@ -371,10 +371,10 @@ public class Parallel extends Simulation {
         @Override
         public void run () {
             synchronized (Parallel.this.threadFilaEventos.get(this.mestre)) {
-                for (final GridTask tarefa : Parallel.this.getJobs()) {
+                for (final var tarefa : Parallel.this.getJobs()) {
                     if (tarefa.getOrigem() == this.mestre) {
                         //criar evento...
-                        final ispd.motor.Event evt = new Event(
+                        final var evt = new Event(
                             tarefa.getTimeCriacao(), EventType.ARRIVAL, tarefa.getOrigem(), tarefa
                         );
                         Parallel.this.threadFilaEventos.get(this.mestre).add(evt);

--- a/src/main/java/ispd/motor/simul/impl/Parallel.java
+++ b/src/main/java/ispd/motor/simul/impl/Parallel.java
@@ -81,7 +81,6 @@ public class Parallel extends Simulation {
 
     @Override
     public void simulate () {
-        System.out.println("Iniciando: " + this.numThreads + " threads");
         this.threadPool = Executors.newFixedThreadPool(this.numThreads);
         this.initSchedulers();
         //Adiciona tarefas iniciais
@@ -91,7 +90,6 @@ public class Parallel extends Simulation {
         this.threadPool.shutdown();
         while (!this.threadPool.isTerminated()) {
         }
-        System.out.println("Iniciando: " + this.numThreads + " threads");
         this.threadPool = Executors.newFixedThreadPool(this.numThreads);
 
         Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
@@ -373,11 +371,6 @@ public class Parallel extends Simulation {
         @Override
         public void run () {
             synchronized (Parallel.this.threadFilaEventos.get(this.mestre)) {
-                System.out.println(
-                    "Nome: "
-                    + Thread.currentThread().getName()
-                    + " Vou criar tarefas do "
-                    + this.mestre.id());
                 for (final GridTask tarefa : Parallel.this.getJobs()) {
                     if (tarefa.getOrigem() == this.mestre) {
                         //criar evento...
@@ -387,10 +380,6 @@ public class Parallel extends Simulation {
                         Parallel.this.threadFilaEventos.get(this.mestre).add(evt);
                     }
                 }
-                System.out.println("Nome: " + Thread.currentThread().getName() + " foram criadas " +
-                                   Parallel.this.threadFilaEventos
-                                       .get(this.mestre)
-                                       .size());
             }
         }
     }

--- a/src/main/java/ispd/motor/simul/impl/Parallel.java
+++ b/src/main/java/ispd/motor/simul/impl/Parallel.java
@@ -20,7 +20,7 @@ public class Parallel extends Simulation {
 
     private final List<Service> recursos;
 
-    private final Map<Service, PriorityBlockingQueue<ispd.motor.Event>> threadFilaEventos;
+    private final Map<Service, PriorityBlockingQueue<Event>> threadFilaEventos;
 
     private final HashMap<Service, ThreadTrabalhador> threadTrabalhador;
 
@@ -117,7 +117,7 @@ public class Parallel extends Simulation {
     }
 
     @Override
-    public void addFutureEvent (final ispd.motor.Event ev) {
+    public void addFutureEvent (final Event ev) {
         if (ev.getType() == EventType.ARRIVAL) {
             this.threadFilaEventos.get(ev.getServidor()).offer(ev);
         } else {

--- a/src/main/java/ispd/policy/allocation/vm/impl/FirstFit.java
+++ b/src/main/java/ispd/policy/allocation/vm/impl/FirstFit.java
@@ -66,11 +66,8 @@ public class FirstFit extends VmAllocationPolicy {
                 this.maqIndex++;
 
                 if (auxMaq instanceof CloudMaster) {
-                    System.out.printf("%s é um VMM, a VM será redirecionada\n", auxMaq.id());
                     auxVM.setCaminho(this.escalonarRota(auxMaq));
-                    System.out.printf("%s enviada para %s\n", auxVM.id(), auxMaq.id());
                     this.mestre.sendVm(auxVM);
-                    System.out.println("---------------------------------------");
                     break;
                 } else {
                     final var maq = (CloudMachine) auxMaq;

--- a/src/main/java/ispd/policy/allocation/vm/impl/FirstFitDecreasing.java
+++ b/src/main/java/ispd/policy/allocation/vm/impl/FirstFitDecreasing.java
@@ -29,17 +29,12 @@ public class FirstFitDecreasing extends VmAllocationPolicy {
         this.maqIndex     = 0;
         this.VMsOrdenadas = new ArrayList<>(this.maquinasVirtuais);
         for (final VirtualMachine aux : this.VMsOrdenadas) {
-            System.out.println(aux.id());
         }
         this.VMsOrdenadas.sort(this.comparaReq);
-        System.out.println("Ordem crescente");
         for (final VirtualMachine aux : this.VMsOrdenadas) {
-            System.out.println(aux.id());
         }
         Collections.reverse(this.VMsOrdenadas);
-        System.out.println("Ordem decrescente");
         for (final VirtualMachine aux : this.VMsOrdenadas) {
-            System.out.println(aux.id());
         }
         if (!this.escravos.isEmpty() && !this.maquinasVirtuais.isEmpty()) {
             this.escalonar();
@@ -55,7 +50,6 @@ public class FirstFitDecreasing extends VmAllocationPolicy {
     @Override
     public void escalonar () {
         while (!(this.maquinasVirtuais.isEmpty())) {
-            System.out.println("------------------------------------------");
             int num_escravos = this.escravos.size();
 
             final VirtualMachine auxVM = this.escalonarVM();
@@ -66,30 +60,18 @@ public class FirstFitDecreasing extends VmAllocationPolicy {
                     // escalona o recurso
                     if (auxMaq instanceof CloudMaster) {
 
-                        System.out.println(auxMaq.id()
-                                           + " é um VMM, a VM "
-                                           + "será redirecionada");
                         auxVM.setCaminho(this.escalonarRota(auxMaq));
                         // salvando uma lista de VMMs intermediarios no caminho da vm e seus respectivos caminhos
-                        System.out.println(auxVM.id() + " enviada para " + auxMaq.id());
                         this.mestre.sendVm(auxVM);
-                        System.out.println("---------------------------------------");
                         break;
                     } else {
-                        System.out.println("Checagem de recursos:");
                         final CloudMachine maq        = (CloudMachine) auxMaq;
                         final double       memoriaMaq = maq.getMemoriaDisponivel();
-                        System.out.println("memoriaMaq: " + memoriaMaq);
                         final double memoriaNecessaria = auxVM.getMemoriaDisponivel();
-                        System.out.println("memorianecessaria: " + memoriaNecessaria);
                         final double discoMaq = maq.getDiscoDisponivel();
-                        System.out.println("discoMaq: " + discoMaq);
                         final double discoNecessario = auxVM.getDiscoDisponivel();
-                        System.out.println("disconecessario: " + discoNecessario);
                         final int maqProc = maq.getProcessadoresDisponiveis();
-                        System.out.println("ProcMaq: " + maqProc);
                         final int procVM = auxVM.getProcessadoresDisponiveis();
-                        System.out.println("ProcVM: " + procVM);
 
                         if ((
                             memoriaNecessaria <= memoriaMaq
@@ -97,23 +79,12 @@ public class FirstFitDecreasing extends VmAllocationPolicy {
                             && procVM <= maqProc
                         )) {
                             maq.setMemoriaDisponivel(memoriaMaq - memoriaNecessaria);
-                            System.out.println("Realizando o controle de " + "recurso:");
-                            System.out.println("memoria atual da maq: " + (
-                                memoriaMaq
-                                - memoriaNecessaria
-                            ));
+
                             maq.setDiscoDisponivel(discoMaq - discoNecessario);
-                            System.out.println("disco atual maq: " + (discoMaq - discoNecessario));
                             maq.setProcessadoresDisponiveis(maqProc - procVM);
-                            System.out.println("proc atual: " + (maqProc - procVM));
                             auxVM.setMaquinaHospedeira((CloudMachine) auxMaq);
                             auxVM.setCaminho(this.escalonarRota(auxMaq));
-                            System.out.println(auxVM.id()
-                                               + " enviada para"
-                                               + " "
-                                               + auxMaq.id());
                             this.mestre.sendVm(auxVM);
-                            System.out.println("---------------------------------------");
 
                             break;
                         } else {
@@ -121,12 +92,9 @@ public class FirstFitDecreasing extends VmAllocationPolicy {
                         }
                     }
                 } else {
-                    System.out.println(auxVM.id() + " foi rejeitada");
                     auxVM.setStatus(VirtualMachineState.REJECTED);
                     this.VMsRejeitadas.add(auxVM);
-                    System.out.println("Adicionada na lista de rejeitadas");
                     num_escravos--;
-                    System.out.println("---------------------------------------");
                 }
             }
         }

--- a/src/main/java/ispd/policy/allocation/vm/impl/FirstFitDecreasing.java
+++ b/src/main/java/ispd/policy/allocation/vm/impl/FirstFitDecreasing.java
@@ -28,14 +28,8 @@ public class FirstFitDecreasing extends VmAllocationPolicy {
         this.fit          = true;
         this.maqIndex     = 0;
         this.VMsOrdenadas = new ArrayList<>(this.maquinasVirtuais);
-        for (final VirtualMachine aux : this.VMsOrdenadas) {
-        }
         this.VMsOrdenadas.sort(this.comparaReq);
-        for (final VirtualMachine aux : this.VMsOrdenadas) {
-        }
         Collections.reverse(this.VMsOrdenadas);
-        for (final VirtualMachine aux : this.VMsOrdenadas) {
-        }
         if (!this.escravos.isEmpty() && !this.maquinasVirtuais.isEmpty()) {
             this.escalonar();
         }

--- a/src/main/java/ispd/policy/allocation/vm/impl/RoundRobin.java
+++ b/src/main/java/ispd/policy/allocation/vm/impl/RoundRobin.java
@@ -17,8 +17,6 @@ public class RoundRobin extends VmAllocationPolicy {
 
     @Override
     public void iniciar () {
-        this.test();
-
         this.physicalMachine = this.escravos.listIterator(0);
 
         if (this.maquinasVirtuais.isEmpty()) {
@@ -52,16 +50,6 @@ public class RoundRobin extends VmAllocationPolicy {
     @Override
     public VirtualMachine escalonarVM () {
         return this.maquinasVirtuais.remove(0);
-    }
-
-    private void test () {
-        if (this.maquinasVirtuais.isEmpty()) {
-            System.out.println("sem vms setadas");
-        }
-        System.out.println("Lista de VMs");
-        this.maquinasVirtuais.stream()
-            .map(Processing::id)
-            .forEach(System.out::println);
     }
 
     private void findMachineForTask (final VirtualMachine vm) {

--- a/src/main/java/ispd/policy/allocation/vm/impl/RoundRobin.java
+++ b/src/main/java/ispd/policy/allocation/vm/impl/RoundRobin.java
@@ -17,9 +17,6 @@ public class RoundRobin extends VmAllocationPolicy {
 
     @Override
     public void iniciar () {
-        System.out.println("---------------------------------------");
-        System.out.println("Alocador RR iniciado");
-
         this.test();
 
         this.physicalMachine = this.escravos.listIterator(0);
@@ -40,7 +37,6 @@ public class RoundRobin extends VmAllocationPolicy {
     @Override
     public void escalonar () {
         while (!(this.maquinasVirtuais.isEmpty())) {
-            System.out.println("------------------------------------------");
             this.findMachineForTask(this.escalonarVM());
         }
     }
@@ -84,63 +80,42 @@ public class RoundRobin extends VmAllocationPolicy {
                 return;
             }
 
-            System.out.println("Checagem de recursos:");
-            final var maq = (CloudMachine) resource;
-            final double memory = maq.getMemoriaDisponivel();
-            System.out.println("memoriaMaq: " + memory);
+            final var    maq          = (CloudMachine) resource;
+            final double memory       = maq.getMemoriaDisponivel();
             final double neededMemory = vm.getMemoriaDisponivel();
-            System.out.println("memorianecessaria: " + neededMemory);
-            final double disk = maq.getDiscoDisponivel();
-            System.out.println("discoMaq: " + disk);
-            final double neededDisk = vm.getDiscoDisponivel();
-            System.out.println("disconecessario: " + neededDisk);
-            final int processors = maq.getProcessadoresDisponiveis();
-            System.out.println("ProcMaq: " + processors);
-            final int procVM = vm.getProcessadoresDisponiveis();
-            System.out.println("ProcVM: " + procVM);
+            final double disk         = maq.getDiscoDisponivel();
+            final double neededDisk   = vm.getDiscoDisponivel();
+            final int    processors   = maq.getProcessadoresDisponiveis();
+            final int    procVM       = vm.getProcessadoresDisponiveis();
 
             if ((neededMemory > memory || neededDisk > disk || procVM > processors)) {
                 machines--;
                 continue;
             }
 
-            System.out.println("Realizando o controle de recurso:");
             final double newMemory = memory - neededMemory;
             maq.setMemoriaDisponivel(newMemory);
-            System.out.printf("memoria atual da maq: %s%n", newMemory);
             final double newDisk = disk - neededDisk;
             maq.setDiscoDisponivel(newDisk);
-            System.out.printf("disco atual maq: %s%n", newDisk);
             final int newProcessors = processors - procVM;
             maq.setProcessadoresDisponiveis(newProcessors);
-            System.out.printf("proc atual: %d%n", newProcessors);
             vm.setMaquinaHospedeira((CloudMachine) resource);
             vm.setCaminho(this.escalonarRota(resource));
-            System.out.printf(
-                "%s enviada para %s%n", vm.id(), resource.id());
             this.mestre.sendVm(vm);
-            System.out.println("---------------------------------------");
 
             return;
         }
     }
 
     private void rejectVm (final VirtualMachine auxVm) {
-        System.out.printf("%s foi rejeitada%n", auxVm.id());
         auxVm.setStatus(VirtualMachineState.REJECTED);
         this.VMsRejeitadas.add(auxVm);
-        System.out.println("Adicionada na lista de rejeitadas");
-        System.out.println("---------------------------------------");
     }
 
     private void redirectVm (
         final VirtualMachine vm, final Processing resource
     ) {
-        System.out.printf(
-            "%s é um VMM, a VM será redirecionada%n", resource.id());
         vm.setCaminho(this.escalonarRota(resource));
-        System.out.printf("%s enviada para %s%n", vm.id(), resource.id());
         this.mestre.sendVm(vm);
-        System.out.println("---------------------------------------");
     }
 }

--- a/src/main/java/ispd/policy/allocation/vm/impl/Volume.java
+++ b/src/main/java/ispd/policy/allocation/vm/impl/Volume.java
@@ -51,7 +51,6 @@ public class Volume extends VmAllocationPolicy {
     @Override
     public void escalonar () {
         while (!(this.maquinasVirtuais.isEmpty())) {
-            System.out.println("------------------------------------------");
             int num_escravos = this.escravos.size();
 
             final VirtualMachine auxVM = this.escalonarVM();
@@ -61,31 +60,18 @@ public class Volume extends VmAllocationPolicy {
                     final Processing auxMaq = this.escalonarRecurso();
                     // escalona o recurso
                     if (auxMaq instanceof CloudMaster) {
-
-                        System.out.println(auxMaq.id()
-                                           + " é um VMM, a VM "
-                                           + "será redirecionada");
                         auxVM.setCaminho(this.escalonarRota(auxMaq));
                         // salvando uma lista de VMMs intermediarios no caminho da vm e seus respectivos caminhos
-                        System.out.println(auxVM.id() + " enviada para " + auxMaq.id());
                         this.mestre.sendVm(auxVM);
-                        System.out.println("---------------------------------------");
                         break;
                     } else {
-                        System.out.println("Checagem de recursos:");
-                        final CloudMachine maq        = (CloudMachine) auxMaq;
-                        final double       memoriaMaq = maq.getMemoriaDisponivel();
-                        System.out.println("memoriaMaq: " + memoriaMaq);
-                        final double memoriaNecessaria = auxVM.getMemoriaDisponivel();
-                        System.out.println("memorianecessaria: " + memoriaNecessaria);
-                        final double discoMaq = maq.getDiscoDisponivel();
-                        System.out.println("discoMaq: " + discoMaq);
-                        final double discoNecessario = auxVM.getDiscoDisponivel();
-                        System.out.println("disconecessario: " + discoNecessario);
-                        final int maqProc = maq.getProcessadoresDisponiveis();
-                        System.out.println("ProcMaq: " + maqProc);
-                        final int procVM = auxVM.getProcessadoresDisponiveis();
-                        System.out.println("ProcVM: " + procVM);
+                        final CloudMachine maq               = (CloudMachine) auxMaq;
+                        final double       memoriaMaq        = maq.getMemoriaDisponivel();
+                        final double       memoriaNecessaria = auxVM.getMemoriaDisponivel();
+                        final double       discoMaq          = maq.getDiscoDisponivel();
+                        final double       discoNecessario   = auxVM.getDiscoDisponivel();
+                        final int          maqProc           = maq.getProcessadoresDisponiveis();
+                        final int          procVM            = auxVM.getProcessadoresDisponiveis();
 
                         if ((
                             memoriaNecessaria <= memoriaMaq
@@ -93,20 +79,11 @@ public class Volume extends VmAllocationPolicy {
                             && procVM <= maqProc
                         )) {
                             maq.setMemoriaDisponivel(memoriaMaq - memoriaNecessaria);
-                            System.out.println("Realizando o controle de recurso:");
-                            System.out.println("memoria atual da maq: " + (
-                                memoriaMaq
-                                - memoriaNecessaria
-                            ));
                             maq.setDiscoDisponivel(discoMaq - discoNecessario);
-                            System.out.println("disco atual maq: " + (discoMaq - discoNecessario));
                             maq.setProcessadoresDisponiveis(maqProc - procVM);
-                            System.out.println("proc atual: " + (maqProc - procVM));
                             auxVM.setMaquinaHospedeira((CloudMachine) auxMaq);
                             auxVM.setCaminho(this.escalonarRota(auxMaq));
-                            System.out.println(auxVM.id() + " enviada para " + auxMaq.id());
                             this.mestre.sendVm(auxVM);
-                            System.out.println("---------------------------------------");
                             this.atualizarVolume();
                             break;
                         } else {
@@ -114,12 +91,9 @@ public class Volume extends VmAllocationPolicy {
                         }
                     }
                 } else {
-                    System.out.println(auxVM.id() + " foi rejeitada");
                     auxVM.setStatus(VirtualMachineState.REJECTED);
                     this.VMsRejeitadas.add(auxVM);
-                    System.out.println("Adicionada na lista de rejeitadas");
                     num_escravos--;
-                    System.out.println("---------------------------------------");
                 }
             }
         }

--- a/src/main/java/ispd/policy/scheduling/cloud/impl/RoundRobin.java
+++ b/src/main/java/ispd/policy/scheduling/cloud/impl/RoundRobin.java
@@ -22,7 +22,6 @@ public class RoundRobin extends CloudSchedulingPolicy {
 
     @Override
     public void iniciar () {
-        System.out.println("iniciou escalonamento RR");
         this.slavesUser = new LinkedList<>();
         this.resources  = this.slavesUser.listIterator(0);
     }
@@ -32,13 +31,11 @@ public class RoundRobin extends CloudSchedulingPolicy {
         final var destination = (Processing) destino;
         final int index       = this.escravos.indexOf(destination);
 
-        System.out.println("traçando rota para a VM: " + destination.id());
         return new ArrayList<>((List<Service>) this.caminhoEscravo.get(index));
     }
 
     @Override
     public void escalonar () {
-        System.out.println("---------------------------");
         final var task      = this.escalonarTarefa();
         final var taskOwner = task.getProprietario();
         this.slavesUser = (LinkedList<Processing>) this.getVMsAdequadas(taskOwner);
@@ -48,8 +45,6 @@ public class RoundRobin extends CloudSchedulingPolicy {
         } else {
             this.scheduleTask(task);
         }
-
-        System.out.println("---------------------------");
     }
 
     @Override
@@ -66,21 +61,12 @@ public class RoundRobin extends CloudSchedulingPolicy {
     }
 
     private void noAllocatedVms (final GridTask task) {
-        System.out.printf(
-            "Não existem VMs alocadas ainda, devolvendo tarefa %d%n",
-            task.getIdentificador()
-        );
         this.adicionarTarefa(task);
         this.mestre.freeScheduler();
     }
 
     private void scheduleTask (final GridTask task) {
         final var resource = this.escalonarRecurso();
-        System.out.printf(
-            "escalonando tarefa %d para:%s%n",
-            task.getIdentificador(),
-            resource.id()
-        );
         task.setLocalProcessamento(resource);
         task.setCaminho(this.escalonarRota(resource));
         this.mestre.sendTask(task);


### PR DESCRIPTION
Remove liberal use of systemout and cleanup code along the way.

Most impacted packages were `motor` and `policy`, but there were some changes in `gui` as well.

`application` remains with its use of `System.out`. In the future, it should be re-engineered to use a MVC architecture. Furthermore, `metrics/General` also needs is view logic to be extracted out.

This closes #37.