### PR TITLE
27 remove support for jar driven behavior

### DIFF
--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -61,7 +61,7 @@ public class ConfiguracaoISPD {
     private static File loadIspdDirectory () {
         final var dir = getDirectory();
 
-        if (dir.getName().endsWith(".jar")) {
+        if (false) {
             return dir.getParentFile();
         } else {
             return new File(".");

--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -258,11 +258,7 @@ public class ConfiguracaoISPD {
     /**
      * Set which was the last model opened.
      */
-    public void setLastFile (final File lastDir) {
-        if (lastDir == null) {
-            return;
-        }
-
-        this.lastModelOpen = lastDir;
+    public void setLastFile (final Optional<? extends File> lastFile) {
+        lastFile.ifPresent(file -> this.lastModelOpen = file);
     }
 }

--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -59,7 +59,6 @@ public class ConfiguracaoISPD {
     }
 
     private static File loadIspdDirectory () {
-        final var dir = getDirectory();
 
         return new File(".");
     }

--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -13,7 +13,7 @@ import org.xml.sax.*;
  */
 public class ConfiguracaoISPD {
 
-    public static final File DIRETORIO_ISPD = new File(".");
+    private static final File DIRETORIO_ISPD = new File(".");
 
     private static final String FILENAME = "configuration.xml";
 

--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -61,11 +61,7 @@ public class ConfiguracaoISPD {
     private static File loadIspdDirectory () {
         final var dir = getDirectory();
 
-        if (false) {
-            return dir.getParentFile();
-        } else {
-            return new File(".");
-        }
+        return new File(".");
     }
 
     private static File getDirectory () {

--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -1,9 +1,7 @@
 package ispd.arquivo.xml;
 
 import ispd.arquivo.xml.utils.*;
-import ispd.gui.*;
 import java.io.*;
-import java.net.*;
 import java.util.*;
 import java.util.logging.*;
 import javax.xml.parsers.*;
@@ -61,17 +59,6 @@ public class ConfiguracaoISPD {
     private static File loadIspdDirectory () {
 
         return new File(".");
-    }
-
-    private static File getDirectory () {
-        final var location =
-            LogExceptions.class.getProtectionDomain().getCodeSource().getLocation();
-
-        try {
-            return new File(location.toURI());
-        } catch (final URISyntaxException ex) {
-            return new File(location.getPath());
-        }
     }
 
     private void readConfigFromDoc (final WrappedDocument doc) {

--- a/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
+++ b/src/main/java/ispd/arquivo/xml/ConfiguracaoISPD.java
@@ -13,7 +13,7 @@ import org.xml.sax.*;
  */
 public class ConfiguracaoISPD {
 
-    public static final File DIRETORIO_ISPD = loadIspdDirectory();
+    public static final File DIRETORIO_ISPD = new File(".");
 
     private static final String FILENAME = "configuration.xml";
 
@@ -54,11 +54,6 @@ public class ConfiguracaoISPD {
                 .getLogger(ConfiguracaoISPD.class.getName())
                 .warning("Error while reading configuration file '%s'".formatted(this.configurationFile));
         }
-    }
-
-    private static File loadIspdDirectory () {
-
-        return new File(".");
     }
 
     private void readConfigFromDoc (final WrappedDocument doc) {

--- a/src/main/java/ispd/gui/MainWindow.java
+++ b/src/main/java/ispd/gui/MainWindow.java
@@ -1152,7 +1152,7 @@ public final class MainWindow extends JFrame {
     }
 
     private void formWindowClosing () {
-        this.configure.setLastFile(this.openFile);
+        this.configure.setLastFile(Optional.ofNullable(this.openFile));
         this.configure.saveCurrentConfig();
 
         if (!this.currentFileHasUnsavedChanges) {


### PR DESCRIPTION
Some work had already been done in previous PRs; this finishes this task by removing jar-specific logic from Configuration file's code.